### PR TITLE
Added ToLeftWeightedRanked 

### DIFF
--- a/NinjaNye.SearchExtensions.Tests.Integration/NinjaNye.SearchExtensions.Tests.Integration.csproj
+++ b/NinjaNye.SearchExtensions.Tests.Integration/NinjaNye.SearchExtensions.Tests.Integration.csproj
@@ -105,6 +105,9 @@
       <DependentUpon>201511120913152_AddOtherChildren.cs</DependentUpon>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NinjaNye.SearchExtensions.Tests/Fluent/FluentRankedTests.cs
+++ b/NinjaNye.SearchExtensions.Tests/Fluent/FluentRankedTests.cs
@@ -21,14 +21,14 @@ namespace NinjaNye.SearchExtensions.Tests.Fluent
 
         private void BuildTestData()
         {
-            _testData.Add(new TestData {Name = "abcd", Description = "efgh", Number = 1});
-            _testData.Add(new TestData {Name = "ijkl", Description = "mnop", Number = 2});
-            _testData.Add(new TestData {Name = "qrst", Description = "uvwx", Number = 3});
-            _testData.Add(new TestData {Name = "yzab", Description = "cdef", Number = 4});
-            _testData.Add(new TestData {Name = "efgh", Description = "ijkl", Number = 5});
-            _testData.Add(new TestData {Name = "UPPER", Description = "CASE", Number = 6});
-            _testData.Add(new TestData {Name = "lower", Description = "case", Number = 7});
-            _testData.Add(new TestData {Name = "tweeter", Description = "cheese", Number = 8});
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Number = 1 });
+            _testData.Add(new TestData { Name = "ijkl", Description = "mnop", Number = 2 });
+            _testData.Add(new TestData { Name = "qrst", Description = "uvwx", Number = 3 });
+            _testData.Add(new TestData { Name = "yzab", Description = "cdef", Number = 4 });
+            _testData.Add(new TestData { Name = "efgh", Description = "ijkl", Number = 5 });
+            _testData.Add(new TestData { Name = "UPPER", Description = "CASE", Number = 6 });
+            _testData.Add(new TestData { Name = "lower", Description = "case", Number = 7 });
+            _testData.Add(new TestData { Name = "tweeter", Description = "cheese", Number = 8 });
         }
 
         [Test]
@@ -42,6 +42,23 @@ namespace NinjaNye.SearchExtensions.Tests.Fluent
             //Assert
             Assert.IsInstanceOf<IEnumerable<IRanked<TestData>>>(result);
         }
+
+        [Test]
+        public void ToRanked_CorrectRankReturned()
+        {
+            var result = _testData.Search(x => x.Name).ContainingAll("wee").ToLeftWeightedRanked();
+            var first = result.OrderByDescending(r => r.Hits).First();
+            var check = first.Hits;
+            //as 'wee' is one char into string, it should add (7 - 1) to the hit count. - should add 6
+            Assert.AreEqual(7, first.Hits);
+
+            result = _testData.Search(x => x.Name).ContainingAll("ete").ToLeftWeightedRanked();
+            first = result.OrderByDescending(r => r.Hits).First();
+
+            //as 'ete' is three char into string, it should add (7 - 3) to the hit count. - should add 4
+            Assert.AreEqual(5, first.Hits);
+        }
+
 
         [Test]
         public void ToRanked_SearchOneColumn_RankIsCorrect()
@@ -79,7 +96,7 @@ namespace NinjaNye.SearchExtensions.Tests.Fluent
         public void ToRanked_CultureSetToIgnoreCase_RankIgnoresCase()
         {
             //Arrange
-            
+
             //Act
             var result = _testData.Search(x => x.Description)
                                       .SetCulture(StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION
Added new method that artificially increases the hit count for a search based on the proximity to the start of the search word being searched in. This gives a higher count to matched instances that are closer to the start of the word.
 
Primary purpose is to allow for partial matching and making a distinction between 

search phrase: "test"
results: 
"thisisatest"
"sometestorother"
"test"

As technically these all have the same hit count, but if you're searching you'd expect the one that closest matched the word to appear first but you can't guarantee that with the hit count alone. 