### PR TITLE
Additional test and bug fix for multiple search params

### DIFF
--- a/NinjaNye.SearchExtensions.Tests/Fluent/FluentRankedTests.cs
+++ b/NinjaNye.SearchExtensions.Tests/Fluent/FluentRankedTests.cs
@@ -11,12 +11,15 @@ namespace NinjaNye.SearchExtensions.Tests.Fluent
     public class FluentRankedTests
     {
         private List<TestData> _testData = new List<TestData>();
-
+        private List<PersonTestData> _persontestData = new List<PersonTestData>();
         [SetUp]
         public void ClassSetup()
         {
             _testData = new List<TestData>();
             BuildTestData();
+
+            _persontestData = new List<PersonTestData>();
+            BuildPersonTestData();
         }
 
         private void BuildTestData()
@@ -30,6 +33,12 @@ namespace NinjaNye.SearchExtensions.Tests.Fluent
             _testData.Add(new TestData { Name = "lower", Description = "case", Number = 7 });
             _testData.Add(new TestData { Name = "tweeter", Description = "cheese", Number = 8 });
         }
+
+        private void BuildPersonTestData()
+        {
+            _persontestData.Add(new PersonTestData { Title = "Lord", FirstName = "Albertino", LastName = "Grahamshire" });
+        }
+
 
         [Test]
         public void ToRanked_SearchedForData_RankedResultIsReturned()
@@ -46,17 +55,31 @@ namespace NinjaNye.SearchExtensions.Tests.Fluent
         [Test]
         public void ToRanked_CorrectRankReturned()
         {
-            var result = _testData.Search(x => x.Name).ContainingAll("wee").ToLeftWeightedRanked();
+            var result = _persontestData.Search(x => x.FirstName).ContainingAll("bert").ToLeftWeightedRanked();
             var first = result.OrderByDescending(r => r.Hits).First();
-            var check = first.Hits;
             //as 'wee' is one char into string, it should add (7 - 1) to the hit count. - should add 6
-            Assert.AreEqual(7, first.Hits);
+            Assert.AreEqual(8, first.Hits);
+           
+            //result = _persontestData.Search(x => x.Name).ContainingAll("ete").ToLeftWeightedRanked();
+            //first = result.OrderByDescending(r => r.Hits).First();
 
-            result = _testData.Search(x => x.Name).ContainingAll("ete").ToLeftWeightedRanked();
-            first = result.OrderByDescending(r => r.Hits).First();
+            ////as 'ete' is three char into string, it should add (7 - 3) to the hit count. - should add 4
+            //Assert.AreEqual(5, first.Hits);
+        }
 
-            //as 'ete' is three char into string, it should add (7 - 3) to the hit count. - should add 4
-            Assert.AreEqual(5, first.Hits);
+        [Test]
+        public void ToRanked_CorrectRankReturnedMultipleParam()
+        {
+            var result2 = _persontestData.Search(x => x.FirstName, x => x.LastName, x => x.Title).ContainingAll("bert").ToLeftWeightedRanked();
+            var second = result2.OrderByDescending(r => r.Hits).First();
+            //as word doesn't match second param at all, shouldn't increase hit count. 
+            Assert.AreEqual(8, second.Hits);
+
+            //result = _persontestData.Search(x => x.Name).ContainingAll("ete").ToLeftWeightedRanked();
+            //first = result.OrderByDescending(r => r.Hits).First();
+
+            ////as 'ete' is three char into string, it should add (7 - 3) to the hit count. - should add 4
+            //Assert.AreEqual(5, first.Hits);
         }
 
 

--- a/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/TestData.cs
+++ b/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/TestData.cs
@@ -19,4 +19,12 @@ namespace NinjaNye.SearchExtensions.Tests.SearchExtensionTests
         public DateTime Start { get; set; }
         public DateTime End { get; set; }
     }
+
+    internal class PersonTestData : TestData
+    {
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string Title { get; set; }
+
+    }
 }

--- a/NinjaNye.SearchExtensions/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
+++ b/NinjaNye.SearchExtensions/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
@@ -76,20 +76,25 @@ namespace NinjaNye.SearchExtensions.Helpers.ExpressionBuilders
             Expression searchTermExpression = Expression.Constant(searchTerm);
             Expression searchTermLengthExpression = Expression.Constant(searchTerm.Length);
             MemberExpression lengthExpression = Expression.Property(stringProperty.Body, ExpressionMethods.StringLengthProperty);
-            var replaceExpression = Expression.Call(stringProperty.Body, ExpressionMethods.ReplaceMethod,
-                                                    searchTermExpression, ExpressionMethods.EmptyStringExpression);
+
+            var replaceExpression = Expression.Call(ExpressionMethods.CustomReplaceMethod, stringProperty.Body, searchTermExpression, ExpressionMethods.EmptyStringExpression, searchOptions.ComparisonTypeExpression);
             var replacedLengthExpression = Expression.Property(replaceExpression, ExpressionMethods.StringLengthProperty);
+
             var characterDiffExpression = Expression.Subtract(lengthExpression, replacedLengthExpression);
             var hitCountExpression = Expression.Divide(characterDiffExpression, searchTermLengthExpression);
 
             var coalesceExpression = Expression.Coalesce(stringProperty.Body, ExpressionMethods.EmptyStringExpression);
             var indexOfExpresion = Expression.Call(coalesceExpression, ExpressionMethods.IndexOfMethod, searchTermExpression);
-            var leftWeightExpression = Expression.Subtract(lengthExpression, indexOfExpresion);
+
+            var equalityCheckExpression = Expression.Equal(indexOfExpresion, Expression.Constant(-1));
+
+            var leftWeightExpressionWithValue = Expression.Subtract(lengthExpression, indexOfExpresion);
+            var leftWeightExpressionWithNoValue = Expression.Constant(0);
+
+            var leftWeightExpression = Expression.Condition(equalityCheckExpression, leftWeightExpressionWithNoValue, leftWeightExpressionWithValue);
 
             var finalHitCounterExpressionOffset = Expression.Add(hitCountExpression, leftWeightExpression);
             return finalHitCounterExpressionOffset;
-
-            // return hitCountExpression;
         }
 
 
@@ -128,7 +133,13 @@ namespace NinjaNye.SearchExtensions.Helpers.ExpressionBuilders
 
             var coalesceExpression = Expression.Coalesce(stringProperty.Body, ExpressionMethods.EmptyStringExpression);
             var indexOfExpresion = Expression.Call(coalesceExpression, ExpressionMethods.IndexOfMethod, searchTermExpression);
-            var leftWeightExpression = Expression.Subtract(lengthExpression, indexOfExpresion);
+
+            var equalityCheckExpression = Expression.Equal(indexOfExpresion, Expression.Constant(-1));
+
+            var leftWeightExpressionWithValue = Expression.Subtract(lengthExpression, indexOfExpresion);
+            var leftWeightExpressionWithNoValue = Expression.Constant(0);
+
+            var leftWeightExpression = Expression.Condition(equalityCheckExpression, leftWeightExpressionWithNoValue, leftWeightExpressionWithValue);
 
             var finalHitCounterExpressionOffset = Expression.Add(hitCountExpression, leftWeightExpression);
             return finalHitCounterExpressionOffset;

--- a/NinjaNye.SearchExtensions/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
+++ b/NinjaNye.SearchExtensions/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
@@ -73,14 +73,12 @@ namespace NinjaNye.SearchExtensions.Helpers.ExpressionBuilders
         /// <returns>Expression equivalent to: [property].Length - ([property].Replace([searchTerm], "").Length) / [searchTerm].Length</returns>
         public static Expression CalculateHitCount_LeftWeighted<T>(Expression<Func<T, string>> stringProperty, string searchTerm)
         {
-  
             Expression searchTermExpression = Expression.Constant(searchTerm);
             Expression searchTermLengthExpression = Expression.Constant(searchTerm.Length);
             MemberExpression lengthExpression = Expression.Property(stringProperty.Body, ExpressionMethods.StringLengthProperty);
-
-            var replaceExpression = Expression.Call(ExpressionMethods.CustomReplaceMethod, stringProperty.Body, searchTermExpression, ExpressionMethods.EmptyStringExpression);
+            var replaceExpression = Expression.Call(stringProperty.Body, ExpressionMethods.ReplaceMethod,
+                                                    searchTermExpression, ExpressionMethods.EmptyStringExpression);
             var replacedLengthExpression = Expression.Property(replaceExpression, ExpressionMethods.StringLengthProperty);
-
             var characterDiffExpression = Expression.Subtract(lengthExpression, replacedLengthExpression);
             var hitCountExpression = Expression.Divide(characterDiffExpression, searchTermLengthExpression);
 
@@ -96,6 +94,10 @@ namespace NinjaNye.SearchExtensions.Helpers.ExpressionBuilders
 
             var finalHitCounterExpressionOffset = Expression.Add(hitCountExpression, leftWeightExpression);
             return finalHitCounterExpressionOffset;
+
+
+
+            
         }
 
 

--- a/NinjaNye.SearchExtensions/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
+++ b/NinjaNye.SearchExtensions/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
@@ -73,11 +73,12 @@ namespace NinjaNye.SearchExtensions.Helpers.ExpressionBuilders
         /// <returns>Expression equivalent to: [property].Length - ([property].Replace([searchTerm], "").Length) / [searchTerm].Length</returns>
         public static Expression CalculateHitCount_LeftWeighted<T>(Expression<Func<T, string>> stringProperty, string searchTerm)
         {
+  
             Expression searchTermExpression = Expression.Constant(searchTerm);
             Expression searchTermLengthExpression = Expression.Constant(searchTerm.Length);
             MemberExpression lengthExpression = Expression.Property(stringProperty.Body, ExpressionMethods.StringLengthProperty);
 
-            var replaceExpression = Expression.Call(ExpressionMethods.CustomReplaceMethod, stringProperty.Body, searchTermExpression, ExpressionMethods.EmptyStringExpression, searchOptions.ComparisonTypeExpression);
+            var replaceExpression = Expression.Call(ExpressionMethods.CustomReplaceMethod, stringProperty.Body, searchTermExpression, ExpressionMethods.EmptyStringExpression);
             var replacedLengthExpression = Expression.Property(replaceExpression, ExpressionMethods.StringLengthProperty);
 
             var characterDiffExpression = Expression.Subtract(lengthExpression, replacedLengthExpression);


### PR DESCRIPTION
hello again! Spotted an issue with the weighting expression the other day. When searching with multiple params, it was adding incorrect weighting if the searchphrase wasn't contained in the text. Added some new equality checks to the expression builders and its happy again. You only really need the EnumerableExpressionHelper.cs changes but i thought i'd send the tests too
