### PR TITLE
Adding project/tests that target .NET portable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,5 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+SearchExtensions.VC.db
+SearchExtensions.VC.db

--- a/NinjaNye.SearchExtensions.Portable.Tests/BuildStringTestsBase.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/BuildStringTestsBase.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests
+{
+    public class BuildStringTestsBase
+    {
+        private const string letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+        protected IList<string> BuildWords(int wordCount, int minSize = 2, int maxSize = 10)
+        {
+            Console.WriteLine("Building {0} words...", wordCount);
+            var result = new List<string>();
+            for (int i = 0; i < wordCount; i++)
+            {
+                string randomWord = BuildRandomWord(minSize, maxSize);
+                result.Add(randomWord);
+            }
+            Console.WriteLine("Built words: {0}", wordCount);
+            return result;
+        }
+
+        protected string BuildRandomWord(int minSize, int maxSize)
+        {
+            var letterCount = RandomInt(minSize, maxSize);
+            var sb = new StringBuilder(letterCount);
+            for (int i = 0; i < letterCount; i++)
+            {
+                var letterIndex = RandomInt(0, 51);
+                sb.Append(letters[letterIndex]);
+            }
+            return sb.ToString();
+        }
+
+        private int RandomInt(int min, int max)
+        {
+            var rng = new RNGCryptoServiceProvider();
+            var buffer = new byte[4];
+
+            rng.GetBytes(buffer);
+            int result = BitConverter.ToInt32(buffer, 0);
+
+            return new Random(result).Next(min, max);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/Fluent/FluentRankedTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/Fluent/FluentRankedTests.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Models;
+using NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.Fluent
+{
+    [TestFixture]
+    public class FluentRankedTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Number = 1 });
+            _testData.Add(new TestData { Name = "ijkl", Description = "mnop", Number = 2 });
+            _testData.Add(new TestData { Name = "qrst", Description = "uvwx", Number = 3 });
+            _testData.Add(new TestData { Name = "yzab", Description = "cdef", Number = 4 });
+            _testData.Add(new TestData { Name = "efgh", Description = "ijkl", Number = 5 });
+            _testData.Add(new TestData { Name = "UPPER", Description = "CASE", Number = 6 });
+            _testData.Add(new TestData { Name = "lower", Description = "case", Number = 7 });
+            _testData.Add(new TestData { Name = "tweeter", Description = "cheese", Number = 8 });
+        }
+
+        [Test]
+        public void ToRanked_SearchedForData_RankedResultIsReturned()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Description).Containing("c").ToRanked();
+
+            //Assert
+            Assert.IsInstanceOf<IEnumerable<IRanked<TestData>>>(result);
+        }
+
+        [Test]
+        public void ToRanked_CorrectRankReturned()
+        {
+            var result = _testData.Search(x => x.Name).ContainingAll("wee").ToRanked();
+            var first = result.OrderByDescending(r => r.Hits).First();
+            //as 'wee' is one char into string, it should add (7 - 1) to the hit count. - should add 6
+            Assert.AreEqual(7, first.Hits);
+
+            result = _testData.Search(x => x.Name).ContainingAll("ete").ToRanked();
+            first = result.OrderByDescending(r => r.Hits).First();
+
+            //as 'ete' is three char into string, it should add (7 - 3) to the hit count. - should add 4
+            Assert.AreEqual(5, first.Hits);
+        }
+
+        [Test]
+        public void ToRanked_SearchOneColumn_RankIsCorrect()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).Containing("e").ToRanked().ToList();
+
+            //Assert
+            Assert.AreEqual(3, result.Count);
+            var first = result.OrderByDescending(r => r.Hits).ToList();
+            Assert.AreEqual(3, first[0].Hits);
+            Assert.AreEqual(1, first[1].Hits);
+        }
+
+        [Test]
+        public void ToRanked_SearchMultipleColumns_RankIsCombined()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description)
+                             .Containing("c")
+                             .ToRanked()
+                             .ToList();
+
+            //Assert
+            Assert.AreEqual(4, result.Count);
+            var ordered = result.OrderByDescending(r => r.Hits).ToList();
+            Assert.AreEqual(1, ordered[0].Hits);
+        }
+
+        [Test]
+        public void ToRanked_CultureSetToIgnoreCase_RankIgnoresCase()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Description)
+                                      .SetCulture(StringComparison.OrdinalIgnoreCase)
+                                      .Containing("c")
+                                      .ToRanked()
+                                      .ToList();
+
+            //Assert
+            Assert.AreEqual(4, result.Count);
+            Assert.IsTrue(result.All(r => r.Hits == 1));
+        }
+
+        [Test]
+        public void ToRanked_SearchRankedSearch_OnlyRetrieveMatchingBothSearches()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name)
+                                      .Containing("e")
+                                      .ToRanked()
+                                      .Search(x => x.Item.Description)
+                                      .Containing("k")
+                                      .StartsWith("i");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual(1, result.First().Hits);
+        }
+
+        [Test]
+        public void ToRanked_SearchedForDataStartingWith_RankedResultIsReturned()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Description)
+                                       .SetCulture(StringComparison.OrdinalIgnoreCase)
+                                       .StartsWith("c").ToRanked();
+
+            //Assert
+            Assert.AreEqual(4, result.Count());
+            Assert.AreEqual(1, result.First().Hits);
+        }
+
+        [Test]
+        public void ToRanked_SearchedForDataEndsWith_RankedResultIsReturned()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Description)
+                                       .EndsWith("e")
+                                       .ToRanked();
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual(1, result.First().Hits);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/Fluent/FluentSearchTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/Fluent/FluentSearchTests.cs
@@ -1,0 +1,354 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.Fluent
+{
+    [TestFixture]
+    public class FluentSearchTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Number = 1 });
+            _testData.Add(new TestData { Name = "ijkl", Description = "mnop", Number = 2 });
+            _testData.Add(new TestData { Name = "qrst", Description = "uvwx", Number = 3 });
+            _testData.Add(new TestData { Name = "yzab", Description = "cdef", Number = 4 });
+            _testData.Add(new TestData { Name = "efgh", Description = "ijkl", Number = 5 });
+            _testData.Add(new TestData { Name = "UPPER", Description = "CASE", Number = 6 });
+            _testData.Add(new TestData { Name = "lower", Description = "case", Number = 7 });
+            _testData.Add(new TestData { Name = "tastiest", Description = "two occurences of st", Number = 8 });
+        }
+
+        [Test]
+        public void Search_SearchWithoutActionHasNoAffectOnTheResults_ResultsAreUnchanged()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name);
+
+            //Assert
+            CollectionAssert.AreEquivalent(_testData, result);
+        }
+
+        [Test]
+        public void Search_FluentCallContaining_OnlyResultsContainingTermAreReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing("abc");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("abc")));
+        }
+
+        [Test]
+        public void Search_FluentCallContaining_SearchEmptyString()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing("");
+
+            //Assert
+            Assert.AreEqual(8, result.Count());
+            CollectionAssert.AreEqual(_testData, result);
+        }
+
+        [Test]
+        public void Search_AfterCallingContainsChainStartsWith_OnlyResultsThatContainTextAndStartWithTextAreReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing("b").StartsWith("a");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("abc") && x.Name.StartsWith("a")));
+        }
+
+        [Test]
+        public void Search_AllowEqualsMethod_DefinedPropertyEqualsSearchResult()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).EqualTo("abcd");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Name == "abcd"));
+        }
+
+        [Test]
+        public void Search_AllowEndsWithAndContainsMethod_AllResultsEndWithSearchTermAndContainSearch()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith("st")
+                                                     .Containing("qr");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.EndsWith("st") && x.Name.Contains("qr")));
+        }
+
+        [Test]
+        public void SearchMultiple_ResultContainsAcrossTwoProperties_ResultContainsTermInEitherProperty()
+        {
+            //Arrange
+            const string searchTerm = "cd";
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).Containing(searchTerm);
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm) || x.Description.Contains(searchTerm)));
+        }
+
+        [Test]
+        public void SearchMultiple_ResultStartsWithAcrossTwoProperties_ResultStartsWithTermInEitherProperty()
+        {
+            //Arrange
+            const string searchTerm = "ef";
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).StartsWith(searchTerm);
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.StartsWith(searchTerm) || x.Description.StartsWith(searchTerm)));
+        }
+
+        [Test]
+        public void SearchAll_NoPropertiesDefined_AllPropertiesAreSearched()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search().Containing("cd");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("cd") || x.Description.Contains("cd")));
+        }
+
+        [Test]
+        public void Search_ContainingMultipleTerms_SearchAgainstMultipleTerms()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).Containing("ab", "jk");
+
+            //Assert
+            Assert.AreEqual(3, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("ab") || x.Name.Contains("jk")));
+        }
+
+        [Test]
+        public void Search_StartsWithMultipleTerms_SearchAgainstMultipleTerms()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).StartsWith("ab", "ef");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.StartsWith("ab") || x.Name.StartsWith("ef")));
+
+        }
+
+        [Test]
+        public void Search_SearchManyPropertiesContainingManyTerms_AllResultsHaveASearchTermWithin()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).Containing("cd", "jk");
+
+            //Assert
+            Assert.AreEqual(4, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("cd") || x.Name.Contains("jk") 
+                                       || x.Description.Contains("cd") || x.Description.Contains("jk")));
+        }
+
+        [Test]
+        public void Search_SearchManyPropertiesStartingWithManyTerms_AllResultsHaveAPropertyStartingWithASpecifiedTerm()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).StartsWith("cd", "ef");
+
+            //Assert
+            Assert.AreEqual(3, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.StartsWith("cd") || x.Name.StartsWith("ef")
+                                       || x.Description.StartsWith("cd") || x.Description.StartsWith("ef")));
+        }
+
+        [Test]
+        public void Search_SearchManyPropertiesEndingWithManyTerms_AllResultsHaveAPropertyEndingWithASpecifiedTerm()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).EndsWith("kl", "ef");
+
+            //Assert
+            Assert.AreEqual(3, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.EndsWith("kl") || x.Name.EndsWith("ef")
+                                       || x.Description.EndsWith("kl") || x.Description.EndsWith("ef")));
+        }
+
+        [Test]
+        public void Search_SearchContainingWithOrdinalStringComparison_OnlyMatchingCaseIsReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).SetCulture(StringComparison.Ordinal).Containing("AB", "jk");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("jk")));
+            Assert.IsFalse(result.Any(x => x.Name.Contains("AB")));
+        }
+
+        [Test]
+        public void Search_SearchContainingWithOrdinalIgnoreCaseStringComparison_CaseIsIgnored()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).SetCulture(StringComparison.OrdinalIgnoreCase).Containing("AB", "jk");
+
+            //Assert
+            Assert.AreEqual(3, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.Contains("jk") || x.Name.Contains("ab")));
+        }
+
+        [Test]
+        public void Search_SearchStartsWithOrdinalStringComparison_OnlyMatchingCaseIsReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Description).SetCulture(StringComparison.Ordinal).StartsWith("C");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Description.StartsWith("C")));
+        }
+
+        [Test]
+        public void Search_SearchStartsWithOrdinalIgnoreCaseStringComparison_CaseIsIgnored()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Description).SetCulture(StringComparison.OrdinalIgnoreCase).StartsWith("C");
+
+            //Assert
+            Assert.AreEqual(3, result.Count());
+            Assert.IsTrue(result.All(x => x.Description.StartsWith("c", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [Test]
+        public void Search_SearchEndsWithOrdinalStringComparison_OnlyMatchingCaseIsReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Description).SetCulture(StringComparison.Ordinal).EndsWith("SE");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Description.EndsWith("SE", StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void Search_SearchEndsWithOrdinalIgnoreCaseStringComparison_CaseIsIgnored()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Description).SetCulture(StringComparison.OrdinalIgnoreCase).EndsWith("SE");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Description.EndsWith("se", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [Test]
+        public void Search_SearchIsEqualOrdinalStringComparison_OnlyMatchingCaseIsReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Description).SetCulture(StringComparison.Ordinal).EqualTo("CASE");
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.All(x => x.Description.EndsWith("CASE", StringComparison.Ordinal)));
+        }
+
+        [Test]
+        public void Search_SearchIsEqualOrdinalIgnoreCaseStringComparison_CaseIsIgnored()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Description).SetCulture(StringComparison.OrdinalIgnoreCase).EqualTo("CASE");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Description.Equals("case", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        [Test]
+        public void Search_SearchManyTermsAreEqual_ResultsMatchAnyTerm()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).EqualTo("abcd", "efgh");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name == "abcd" || x.Name == "efgh"));
+        }
+
+        [Test]
+        public void Search_SearchManyTermsAreEqualIgnoringCase_ResultsMatchAnyTermInAnyCase()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name)
+                                 .SetCulture(StringComparison.OrdinalIgnoreCase)
+                                 .EqualTo("ABCD", "EFGH");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name == "abcd" || x.Name == "efgh"));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/Fluent/ReverseSoundexSearchTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/Fluent/ReverseSoundexSearchTests.cs
@@ -1,0 +1,68 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Soundex;
+using NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.Fluent
+{
+    [TestFixture]
+    public class ReverseSoundexSearchTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Name = "arrange", Description = "", Number = 1 });
+            _testData.Add(new TestData { Name = "estrange", Description = "", Number = 2 });
+            _testData.Add(new TestData { Name = "Taint", Description = "", Number = 3 });
+            _testData.Add(new TestData { Name = "Paint", Description = "", Number = 4 });
+        }
+
+        [Test]
+        public void SoundsLike_SearchSingleWord_ReturnsMatchingRecord()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).ReverseSoundex("range");
+
+            //Assert
+            CollectionAssert.Contains(result, _testData[0]);
+        }
+
+        [Test]
+        public void SoundsLike_SearchSingleWord_DoesNotReturnsNonMatchingRecords()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).ReverseSoundex("range");
+
+            //Assert
+            CollectionAssert.DoesNotContain(result, _testData[3]);
+        }
+
+        [Test]
+        public void SoundsLike_SearchMultipleWords_ReturnsAllMatchingRecords()
+        {
+            //Arrange
+            var names = new[] { "range", "point" };
+            var soundexCodes = names.Select(w => w.ToReverseSoundex());
+            var expected = _testData.Where(td => soundexCodes.Contains(td.Name.ToReverseSoundex()));
+
+            //Act
+            var result = _testData.Search(x => x.Name).ReverseSoundex(names);
+
+            //Assert
+            CollectionAssert.AreEqual(expected, result);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/Fluent/SoundexSearchTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/Fluent/SoundexSearchTests.cs
@@ -1,0 +1,70 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Soundex;
+using NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.Fluent
+{
+    [TestFixture]
+    public class SoundexSearchTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData {Name = "Robert", Description = "Sounds like Rupert", Number = 1});
+            _testData.Add(new TestData {Name = "Rupert", Description = "SOunds like Robert", Number = 2});
+            _testData.Add(new TestData {Name = "John", Description = "Sounds like Jon", Number = 3});
+            _testData.Add(new TestData {Name = "Jon", Description = "Sounds like John", Number = 4});
+            _testData.Add(new TestData {Name = "Matt", Description = "Sounds like Mitt", Number = 5});
+            _testData.Add(new TestData {Name = "Aschcraft", Description = "Sounds like Ashcroft", Number = 6});
+        }
+
+        [Test]
+        public void SoundsLike_SearchSingleWord_ReturnsMatchingRecord()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Soundex("Robert");
+
+            //Assert
+            CollectionAssert.Contains(result, _testData[0]);
+        }
+
+        [Test]
+        public void SoundsLike_SearchSingleWord_DoesNotReturnsNonMatchingRecords()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Soundex("Robert");
+
+            //Assert
+            CollectionAssert.DoesNotContain(result, _testData[5]);
+        }
+
+        [Test]
+        public void SoundsLike_SearchMultipleWords_ReturnsAllMatchingRecords()
+        {
+            //Arrange
+            var names = new[] {"Robert", "Mitt"};
+            var soundexCodes = names.Select(w => w.ToSoundex());
+            var expected = _testData.Where(td => soundexCodes.Contains(td.Name.ToSoundex()));            
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Soundex("Robert", "Mitt");
+
+            //Assert
+            CollectionAssert.AreEqual(expected, result);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/Helpers/StringExtensionTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/Helpers/StringExtensionTests.cs
@@ -1,0 +1,73 @@
+﻿using NinjaNye.SearchExtensions.Portable.Helpers;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.Helpers
+{
+    [TestFixture]
+    public class StringExtensionTests
+    {
+        [Test]
+        public void GetFirstCharacter_EmptyString_ReturnsNull()
+        {
+            //Arrange
+
+            //Act
+            var character = string.Empty.GetFirstCharacter();
+
+            //Assert
+            Assert.IsNull(character);
+        }
+
+        [Test]
+        public void GetFirstCharacter_ValidString_ReturnedValueIsNotNull()
+        {
+            //Arrange
+            string word = "test";
+
+            //Act
+            var character = word.GetFirstCharacter();
+
+            //Assert
+            Assert.IsNotNullOrEmpty(character);
+        }
+
+        [Test]
+        public void GetFirstCharacter_ValidString_ReturnedValueIsFirstCharacterOnly()
+        {
+            //Arrange
+            string word = "test";
+
+            //Act
+            var character = word.GetFirstCharacter();
+
+            //Assert
+            Assert.AreEqual(word[0].ToString(), character);
+        }
+
+        [Test]
+        public void GetFirstCharacter_StringIsWhitespaceOnly_ReturnNull()
+        {
+            //Arrange
+            string word = "   ";
+
+            //Act
+            var character = word.GetFirstCharacter();
+
+            //Assert
+            Assert.IsNull(character);
+        }
+
+        [Test]
+        public void GetFirstCharacter_StringBeginsWithWhitespace_ReturnFirstNonWhitespaceCharacter()
+        {
+            //Arrange
+            string word = " test";
+
+            //Act
+            var character = word.GetFirstCharacter();
+
+            //Assert
+            Assert.AreEqual("t", character);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/LevenshteinTests/LevenshteinDistancePerformanceTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/LevenshteinTests/LevenshteinDistancePerformanceTests.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Levenshtein;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.LevenshteinTests
+{
+#if DEBUG
+    // Performance tests will likely fail in debug mode
+    [Ignore("Performance tests will likely fail in debug mode. Run in release mode")]
+#endif
+    [TestFixture]
+    public class LevenshteinDistancePerformanceTests : BuildStringTestsBase
+    {
+        [TestCase(6)]
+        [TestCase(7)]
+        public void ToLevenshteinDistance_CompareOneMillionStringsOfLengthX_ExecutesInLessThanOneSecond(int length)
+        {
+            //Arrange
+            var words = BuildWords(1000000, length, length);
+            var randomWord = BuildRandomWord(length,length);
+            var stopwatch = new Stopwatch();
+            //Act
+            stopwatch.Start();
+            var result = words.Select(w => LevenshteinProcessor.LevenshteinDistance(w, randomWord)).ToList();
+            stopwatch.Stop();
+
+            //Assert
+            Console.WriteLine("Elapsed Time: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Total matching words: {0}", result.Count(i => i == 0));
+            Console.WriteLine("Total words with distance of 1: {0}", result.Count(i => i == 1));
+            Console.WriteLine("Total words with distance of 2: {0}", result.Count(i => i == 2));
+            Console.WriteLine("Total words with distance of 3: {0}", result.Count(i => i == 3));
+            Assert.That(stopwatch.Elapsed.TotalMilliseconds, Is.LessThan(1000));
+        }
+
+        [Test]
+        public void PerformLevenshteinDistanceUsingExpressionTreeBuilder()
+        {
+            //Setup 1 million comparisons
+            var words = BuildWords(100000, 6, 6);
+            var wordsToCompareTo = BuildWords(10, 6, 6).ToArray();
+            var stopwatch = new Stopwatch();
+
+            //Act
+            stopwatch.Start();
+            var result = words.LevenshteinDistanceOf(x => x).ComparedTo(wordsToCompareTo).ToList();
+            stopwatch.Stop();
+
+            //Assert
+            Console.WriteLine("Elapsed Time: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Total matching words: {0}", result.Count(i => i.MinimumDistance == 0));
+            Console.WriteLine("Total words with distance of 1: {0}", result.Count(i => i.MinimumDistance == 1));
+            Console.WriteLine("Total words with distance of 2: {0}", result.Count(i => i.MinimumDistance == 2));
+            Console.WriteLine("Total words with distance of 3: {0}", result.Count(i => i.MinimumDistance == 3));
+            Assert.That(stopwatch.Elapsed.TotalMilliseconds, Is.LessThan(1000));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/LevenshteinTests/LevenshteinDistanceTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/LevenshteinTests/LevenshteinDistanceTests.cs
@@ -1,0 +1,141 @@
+﻿using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Levenshtein;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.LevenshteinTests
+{
+    [TestFixture]
+    public class LevenshteinDistanceTests
+    {
+        [Test]
+        public void LevenshteinDistance_DefaultBehaviour_DoesNotThrowAnException()
+        {
+            //Arrange
+            
+            //Act
+            LevenshteinProcessor.LevenshteinDistance("", "");
+
+            //Assert
+            Assert.Pass("No exception thrown");
+        }
+
+        [Test]
+        public void LevenshteinDistance_AcceptsTwoStrings_ReturnsUnsignedInteger()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("string", "string");
+
+            //Assert
+            Assert.IsInstanceOf<int>(result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_FirstStringIsEmpty_ReturnLengthOfSecondString()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance(string.Empty, "string");
+
+            //Assert
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_SecondStringIsEmpty_ReturnLengthOfFirstString()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("test", string.Empty);
+
+            //Assert
+            Assert.AreEqual(4, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_StringsAreEqual_ReturnZero()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("test", "test");
+
+            //Assert
+            Assert.AreEqual(0, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_BothStringsNull_ReturnZero()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance(null, null);
+
+            //Assert
+            Assert.AreEqual(0, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_StringsDiffer_ReturnGreaterThanZero()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("Ninja", "Nye");
+
+            //Assert
+            Assert.Greater(result, 0);
+        }
+
+        [Test]
+        public void LevenshteinDistance_StringsAreEqualExceptForCase_ReturnZero()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("test", "TEST");
+
+            //Assert
+            Assert.AreEqual(0, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_StringsDifferByTwoCharacters_ReturnTwo()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("Barry", "Lorry");
+
+            //Assert
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_StringsDifferByTwoCharactersAndCasing_ReturnTwo()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("Barry", "LORRY");
+
+            //Assert
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void LevenshteinDistance_StringsDifferByNonLinearChanges_ReturnTwo()
+        {
+            //Arrange
+
+            //Act
+            var result = LevenshteinProcessor.LevenshteinDistance("house", "use");
+
+            //Assert
+            Assert.AreEqual(2, result);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/NinjaNye.SearchExtensions.Portable.Tests.csproj
+++ b/NinjaNye.SearchExtensions.Portable.Tests/NinjaNye.SearchExtensions.Portable.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{A2B64396-FE41-4F02-9A11-5050F16524C3}</ProjectGuid>
+    <ProjectGuid>{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>NinjaNye.SearchExtensions.Tests</RootNamespace>
-    <AssemblyName>NinjaNye.SearchExtensions.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <RootNamespace>NinjaNye.SearchExtensions.Portable.Tests</RootNamespace>
+    <AssemblyName>NinjaNye.SearchExtensions.Portable.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -35,9 +35,24 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+    <Reference Include="nunit.core, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.core.interfaces, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.core.interfaces.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.util, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\nunit.util.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="NUnit.VisualStudio.TestAdapter, Version=2.0.0.0, Culture=neutral, PublicKeyToken=4cb40d35494691ac, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnitTestAdapter.2.0.0\lib\NUnit.VisualStudio.TestAdapter.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>
@@ -62,8 +77,8 @@
     <Compile Include="SearchExtensionTests\IEnumerableTests\ContainingAllTests.cs" />
     <Compile Include="SearchExtensionTests\IEnumerableTests\ContainingTests.cs" />
     <Compile Include="SearchExtensionTests\IEnumerableTests\ContainingWholeWordTests.cs" />
-    <Compile Include="SearchExtensionTests\IEnumerableTests\EndsWithTests.cs" />
     <Compile Include="SearchExtensionTests\IEnumerableTests\DateTimeSearchTests.cs" />
+    <Compile Include="SearchExtensionTests\IEnumerableTests\EndsWithTests.cs" />
     <Compile Include="SearchExtensionTests\IEnumerableTests\IntegerSearchTests.cs" />
     <Compile Include="SearchExtensionTests\IEnumerableTests\IsEqualTests.cs" />
     <Compile Include="SearchExtensionTests\IEnumerableTests\LevenshteinSearch.cs" />
@@ -78,17 +93,16 @@
     <Compile Include="SoundexTests\ToSoundexPerformanceTests.cs" />
     <Compile Include="SoundexTests\ToSoundexTests.cs" />
   </ItemGroup>
-  <ItemGroup />
-  <ItemGroup>
-    <ProjectReference Include="..\NinjaNye.SearchExtensions\NinjaNye.SearchExtensions.csproj">
-      <Project>{60b8e347-999f-4ee2-8172-9367d4f71860}</Project>
-      <Name>NinjaNye.SearchExtensions</Name>
-    </ProjectReference>
-  </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\NinjaNye.SearchExtensions.Portable\NinjaNye.SearchExtensions.Portable.csproj">
+      <Project>{8eb3d1b8-0592-471a-829b-b7c776c37caa}</Project>
+      <Name>NinjaNye.SearchExtensions.Portable</Name>
+    </ProjectReference>
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">

--- a/NinjaNye.SearchExtensions.Portable.Tests/Properties/AssemblyInfo.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NinjaNye.SearchExtensions.Portable.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("LHP")]
+[assembly: AssemblyProduct("NinjaNye.SearchExtensions.Portable.Tests")]
+[assembly: AssemblyCopyright("Copyright © LHP 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fafe908a-dba5-45fb-8562-6a1a38482f6a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/ContainingAllTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/ContainingAllTests.cs
@@ -1,0 +1,121 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class ContainingAllTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Status = "ijkl", Number = 1 });
+            _testData.Add(new TestData { Name = "a test", Description = "ijkl", Status = "mnop", Number = 2 });
+            _testData.Add(new TestData { Name = "search test", Description = "mnop", Status = "qrst", Number = 3 });
+            _testData.Add(new TestData { Name = "search", Description = "test three", Status = "search", Number = 4 });
+            _testData.Add(new TestData { Name = "search test property match", Description = "test", Status = "match", Number = 5 });
+        }
+
+        [Test]
+        public void ContainingAll_OneTermSupplied_ReturnsRecordNumber2()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).ContainingAll("test").ToList();
+
+            //Assert
+            Assert.IsTrue(result.Any(r => r.Number == 2));
+        }
+
+        [Test]
+        public void ContainingAll_TwoTermsSupplied_ReturnsRecordNumber3()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).ContainingAll("test", "search").ToList();
+
+            //Assert
+            Assert.IsTrue(result.Any(r => r.Number == 3));
+        }
+
+        [Test]
+        public void ContainingAll_TwoPropertiesAndTwoTermsSupplied_ReturnsRecordNumber3()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description)
+                                 .ContainingAll("test", "search", "three").ToList();
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.Any(r => r.Number == 4));
+        }
+
+        [Test]
+        public void ContainingAll_CompareAgainstOneProperty_DoesNotThrowAnException()
+        {
+            //Arrange
+            
+            //Act
+
+            //Assert
+            Assert.DoesNotThrow(() => _testData.Search(x => x.Name).ContainingAll(x => x.Description));
+        }
+
+        [Test]
+        public void ContainingAll_CompareAgainstOneProperty_DoesNotReturnNull()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).ContainingAll(x => x.Description);
+
+            //Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void ContainingAll_CompareAgainstOneProperty_ResultNameContainsDescription()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).ContainingAll(x => x.Description).ToList();
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Name.Contains(x.Description)));
+        }
+
+        [Test]
+        public void ContainingAll_CompareAgainstTwoProperties_ResultNameContainsDescriptionAndStatus()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).ContainingAll(x => x.Description, x => x.Status).ToList();
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Name.Contains(x.Description) && x.Name.Contains(x.Status)));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/ContainingTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/ContainingTests.cs
@@ -1,0 +1,102 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class ContainingTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+        private readonly TestData _matchingItem1 = new TestData { Name = "searching this", Description = "chin" };
+        private readonly TestData _matchingItem2 = new TestData { Name = "searching this", Description = "sea" };
+        private readonly TestData _matchingItem3 = new TestData { Name = "look here", Description = "sea", Status = "chelsea"};
+        private readonly TestData _matchingItem4 = new TestData { Name = "in status", Description = "miss", Status = "status"};
+        private readonly TestData _unmatchingItem = new TestData { Name = "searching this", Description = "no match", Number = 1 };
+        private readonly TestData _nullItem = new TestData();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(_matchingItem1);
+            _testData.Add(_unmatchingItem);
+            _testData.Add(_matchingItem2);
+            _testData.Add(_matchingItem3);
+            _testData.Add(_nullItem);
+            _testData.Add(_matchingItem4);
+        }
+
+        [Test]
+        public void Containing_CompareAgainstAnotherProperty_DoesNotThrowAnException()
+        {
+            //Arrange
+            
+            //Act
+            _testData.Search(x => x.Name).Containing(x => x.Description);
+
+            //Assert
+            Assert.Pass("No exception thrown");
+        }
+
+        [Test]
+        public void Containing_ComapareAgainstAnotherProperty_DoesNotReturnUnmatchedData()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing(x => x.Description);
+
+            //Assert
+            CollectionAssert.DoesNotContain(result, _unmatchingItem);
+        }
+
+        [Test]
+        public void Containing_ComapareAgainstAnotherProperty_ReturnsAllMatchedData()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing(x => x.Description).ToList();
+
+            //Assert
+            Assert.AreEqual(2, result.Count);
+            CollectionAssert.Contains(result, _matchingItem2);
+        }
+
+        [Test]
+        public void Containing_SearchTwoProperties_ReturnsRecordWithMatchedDataInSecondProperty()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Status).Containing(x => x.Description).ToList();
+
+            //Assert
+            CollectionAssert.Contains(result, _matchingItem3);
+        }
+
+        [Test]
+        public void Containing_SearchAgainstMultipleProperties_ReturnMatchingItemOnSecondProperty()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing(x => x.Description, x => x.Status).ToList();
+
+            //Assert
+            CollectionAssert.Contains(result, _matchingItem4);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/ContainingWholeWordTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/ContainingWholeWordTests.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class ContainingWholeWordTests
+    {
+        [Test]
+        public void Containing_SearchWholeWordsOnly_CorrectResultReturned()
+        {
+            //Arrange
+            var expected = new TestData{Description = "an expected result"};
+            var unexpected = new TestData{Description = "an unexpected result"};
+            var data = new List<TestData> {expected, unexpected};
+
+            //Act
+            var result = data.Search(x => x.Description)
+                .Matching(SearchType.WholeWords)
+                .Containing("expected")
+                .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(expected));
+        }
+
+        [Test]
+        public void Containing_SearchWholeWordsOnly_ResultReturnedIfMatchingWordIsFirstWord()
+        {
+            //Arrange
+            var expected = new TestData{Description = "expect result"};
+            var unexpected = new TestData{Description = "expecting another result"};
+            var data = new List<TestData> {expected, unexpected};
+
+            //Act
+            var result = data.Search(x => x.Description)
+                .Matching(SearchType.WholeWords)
+                .Containing("expect")
+                .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(expected));
+        }
+
+        [Test]
+        public void Containing_SearchWholeWordsOnly_ResultReturnedIfMatchingWordIsLastWord()
+        {
+            //Arrange
+            var expected = new TestData{Description = "result expected"};
+            var unexpected = new TestData { Description = "result unexpected" };
+            var data = new List<TestData> {expected, unexpected};
+
+            //Act
+            var result = data.Search(x => x.Description)
+                .Matching(SearchType.WholeWords)
+                .Containing("expected")
+                .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(expected));
+        }
+
+        [Test]
+        public void Containing_SearchWholeWordsOnly_ResultReturnedIfMatchingWordOnlyWord()
+        {
+            //Arrange
+            var expected = new TestData{Description = "expected"};
+            var unexpected = new TestData { Description = "unexpected" };
+            var data = new List<TestData> {expected, unexpected};
+
+            //Act
+            var result = data.Search(x => x.Description)
+                .Matching(SearchType.WholeWords)
+                .Containing("expected")
+                .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(expected));
+        }
+
+        [Test]
+        public void Containing_ChangeMatchType_CorrectResultReturned()
+        {
+            //Arrange
+            var expected = new TestData { Description = "an expected result" };
+            var unexpected = new TestData { Description = "an not expected item" };
+            var data = new List<TestData> { expected, unexpected };
+
+            //Act
+            var result = data.Search(x => x.Description)
+                .Matching(SearchType.WholeWords)
+                .Containing("expected")
+                .Matching(SearchType.AnyOccurrence)
+                .Containing("res")
+                .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(expected));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/DateTimeSearchTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/DateTimeSearchTests.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class DateTimeSearchTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Start = new DateTime(2000, 1, 1), End = new DateTime(2010, 1, 1) });
+            _testData.Add(new TestData { Start = new DateTime(2010, 1, 1), End = new DateTime(2020, 1, 1) });
+            _testData.Add(new TestData { Start = new DateTime(2020, 1, 1), End = new DateTime(2030, 1, 1) });
+            _testData.Add(new TestData { Start = new DateTime(2030, 1, 1), End = new DateTime(2040, 1, 1) });
+        }
+
+        [Test]
+        public void Search_SearchConditionNotSupplied_ReturnsAllData()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Start);
+
+            //Assert
+            CollectionAssert.AreEquivalent(_testData, result);
+        }
+
+        [Test]
+        public void IsEqual_SearchOnePropertyForMatchingNumber_ReturnsMatchingData()
+        {
+            //Arrange
+            var expected = new DateTime(2010, 1, 1);
+            
+            //Act
+            var result = _testData.Search(x => x.Start).EqualTo(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start == expected));
+        }
+
+        [Test]
+        public void IsEqual_SearchTwoValues_ReturnsMatchingDataOnly()
+        {
+            //Arrange
+            var date1 = new DateTime(2020, 1, 1);
+            var date2 = new DateTime(2040, 1, 1);
+            
+            //Act
+            var result = _testData.Search(x => x.End)
+                                      .EqualTo(date1, date2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.End == date1 || x.End == date2));
+        }
+
+        [Test]
+        public void IsEqual_SearchTwoProperties_ReturnsMatchingDataOnly()
+        {
+            //Arrange
+            var expected = new DateTime(2030, 1, 1);
+            
+            //Act
+            var result = _testData.Search(x => x.Start, x => x.End)
+                                      .EqualTo(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start == expected || x.End == expected));
+        }
+
+        [Test]
+        public void GreaterThan_SearchOneProperty_ReturnsOnlyDataWherePropertyIsGreaterThanValue()
+        {
+            //Arrange
+            var expected = new DateTime(2020, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start).GreaterThan(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start > expected));
+        }
+
+        [Test]
+        public void GreaterThan_SearchTwoProperties_ReturnsOnlyDataWherePropertyIsGreaterThanValue()
+        {
+            //Arrange
+            var expected = new DateTime(2020, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start, x => x.End).GreaterThan(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start > expected || x.End > expected));
+        }
+
+        [Test]
+        public void LessThan_SearchOneProperty_ReturnsOnlyDataWherePropertyIsLessThanValue()
+        {
+            //Arrange
+            var expected = new DateTime(2030, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.End).LessThan(expected);  
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.End < expected));
+        }
+
+        [Test]
+        public void LessThan_SearchTwoProperties_ReturnsOnlyDataWhereEitherPropertyIsLessThanValue()
+        {
+            //Arrange
+            var expected = new DateTime(2030, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start, x => x.End).LessThan(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start < expected || x.End < expected));
+        }
+
+        [Test]
+        public void LessThanOrEqual_SearchOneProperty_ReturnsOnlyDataWherePropertyIsLessThanOrEqualToValue()
+        {
+            //Arrange
+            var expected = new DateTime(2030, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start).LessThanOrEqualTo(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start <= expected));
+        }
+
+        [Test]
+        public void LessThanOrEqual_SearchTwoProperties_ReturnsOnlyDataWhereEitherPropertyIsLessThanOrEqualToValue()
+        {
+            //Arrange
+            var expected = new DateTime(2030, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start, x => x.End)
+                                      .LessThanOrEqualTo(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start <= expected || x.End <= expected));
+        }
+
+        [Test]
+        public void GreaterThanOrEqual_SearchOneProperty_ReturnsOnlyDataWherePropertyIsGreaterThanOrEqualToValue()
+        {
+            //Arrange
+            var expected = new DateTime(2030, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start).GreaterThanOrEqualTo(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start >= expected));
+        }
+
+        [Test]
+        public void GreaterThanOrEqual_SearchTwoProperties_ReturnsOnlyDataWhereEitherPropertyIsGreaterThanOrEqualToValue()
+        {
+            //Arrange
+            var expected = new DateTime(2020, 1, 1);
+
+            //Act
+            var result = _testData.Search(x => x.Start, x => x.End)
+                                      .GreaterThanOrEqualTo(expected);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start >= expected || x.End >= expected));
+        }
+
+        [Test]
+        public void GreaterThanOrLessThan_SearchOnePropertyBetweenTwoValues_OnlyRecordsBetweenValuesReturned()
+        {
+            //Arrange
+            
+            //Act
+            var greaterThanDate = new DateTime(2020, 1, 1);
+            var lessThanDate = new DateTime(2040, 1, 1);
+            var result = _testData.Search(x => x.Start)
+                                      .GreaterThan(greaterThanDate)
+                                      .LessThan(lessThanDate);
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Start > greaterThanDate && x.Start < lessThanDate));
+        }
+
+        [Test]
+        public void Between_SearchTwoPropertiesBetweenTwoValues_OnlyRecordsBetweenValuesReturned()
+        {
+            //Arrange
+            var start = new DateTime(2020, 1, 1);
+            var end = new DateTime(2040, 1, 1);
+            
+            //Act
+            var result = _testData.Search(x => x.Start, x => x.End)
+                                      .Between(start, end);
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => (x.Start > start && x.Start < end)
+                                       || (x.End > start && x.End < end)));
+        }
+
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/EndsWithTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/EndsWithTests.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class EndsWithTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        [Test]
+        public void EndsWith_ComparedToAnExistingProperty_DoesNotThrowAnException()
+        {
+            //Arrange
+            
+            //Act
+
+            //Assert
+            Assert.DoesNotThrow(() => _testData.Search(x => x.Name).EndsWith(x => x.Description));
+        }
+
+        [Test]
+        public void EndsWith_ComparedToAnExistingProperty_ResultIsNotNull()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith(x => x.Description);
+
+            //Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void Search_AllowEndsWithMethod_AllResultsEndWithSearchTerm()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "test" });
+            _testData.Add(new TestData { Name = "false" });
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith("st");
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Name.EndsWith("st")));
+        }
+
+        [Test]
+        public void Search_EndsWithMultipleTerms_SearchAgainstMultipleTerms()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "abcd" });
+            _testData.Add(new TestData { Name = "efgh" });
+            var notPresent = new TestData {Name = "not found"};
+            _testData.Add(notPresent);
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith("cd", "gh");
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsFalse(result.Contains(notPresent));
+        }
+
+        [Test]
+        public void EndsWith_ComparedToAnExistingProperty_ResultEndsWithExistingProperty()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "efgh", Description = "gh" });
+            var notPresent = new TestData {Name = "no match", Description = "test"};
+            _testData.Add(notPresent);
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith(x => x.Description);
+
+            //Assert
+            Assert.IsTrue(result.Any(), "No records returned");
+            Assert.IsFalse(result.Contains(notPresent));
+        }
+
+        [Test]
+        public void EndsWith_ComparedToTwoExistingProperties_ResultEndsWithEitherOfExistingProperties()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "abcd", Status = "cd" });
+            _testData.Add(new TestData { Name = "efgh", Description = "gh" });
+            var notPresent = new TestData { Name = "no match", Description = "test" };
+            _testData.Add(notPresent);
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith(x => x.Description, x => x.Status);
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsFalse(result.Contains(notPresent));
+        }
+
+        [Test]
+        public void EndsWith_ComparedToTwoExistingPropertiesWithNullValue_NullValueIsIgnored()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "abcd", Description = "no match", Status = "cd" });
+            _testData.Add(new TestData { Name = "efgh", Description = "gh" });
+            var notPresent = new TestData { Name = "no match", Description = "test" };
+            _testData.Add(notPresent);
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith(x => x.Description, x => x.Status);
+
+            //Assert
+            Assert.IsTrue(result.Any(), "No records returned");
+            Assert.IsTrue(result.All(x => x.Name.EndsWith(x.Description) || (x.Status != null && x.Name.EndsWith(x.Status))));
+        }
+
+        [Test]
+        public void EndsWith_SearchTwoPropertiesComparedToAProperty_ResultsContainAllPermiatations()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Status = "cd" });
+            _testData.Add(new TestData { Name = "zzzz", Description = "match", Status = "ch"});
+            _testData.Add(new TestData { Name = "zzzz", Description = "yyyy", Status = "xxxx"});
+
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).EndsWith(x => x.Status);
+
+            //Assert
+            Assert.AreEqual(2, result.Count(), "Not enough records returned");
+            Assert.IsTrue(result.All(x => x.Name.EndsWith(x.Status) || x.Description.EndsWith(x.Status)));
+        }
+
+        [Test]
+        public void EndsWith_SearchPropertyWithIgnoreCaseCulture_ResultsAreCaseInsensitive()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "a TEST", Description = "test" });
+            _testData.Add(new TestData { Name = "zzzz", Description = "yyyy" });
+
+            //Act
+            var result = _testData.Search(x => x.Name)
+                                      .SetCulture(StringComparison.OrdinalIgnoreCase)
+                                      .EndsWith(x => x.Description);
+
+            //Assert
+            Assert.AreEqual(1, result.Count());
+            Assert.IsTrue(result.Any(t => t.Description == "test"));
+        }
+
+        [Test]
+        public void EndsWith_SearchOccursTwice_ReturnExpectedRecord()
+        {
+            //Arrange
+            _testData.Add(new TestData { Name = "tastiest", Description = "two occurences of st", Number = 8 });
+
+            //Act
+            var result = _testData.Search(x => x.Name).EndsWith("st");
+
+            //Assert
+            Assert.IsTrue(result.Any(td => td.Number == 8));
+        }
+
+        [Test]
+        public void EndsWith_SerchAcrossTwoProperties_ResultEndsWithTermInEitherProperty()
+        {
+            //Arrange
+            const string searchTerm = "test";
+            _testData.Add(new TestData { Name = "a test", Description = "zzzz" });
+            _testData.Add(new TestData { Name = "zzzz", Description = "another test" });
+
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).EndsWith(searchTerm);
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+            Assert.IsTrue(result.All(x => x.Name.EndsWith(searchTerm) || x.Description.EndsWith(searchTerm)));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/IntegerSearchTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/IntegerSearchTests.cs
@@ -1,0 +1,219 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class IntegerSearchTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Number = 1, Age = 5 });
+            _testData.Add(new TestData { Number = 2, Age = 6 });
+            _testData.Add(new TestData { Number = 3, Age = 7 });
+            _testData.Add(new TestData { Number = 4, Age = 8 });
+        }
+
+        [Test]
+        public void Search_SearchConditionNotSupplied_ReturnsAllData()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Number);
+
+            //Assert
+            CollectionAssert.AreEquivalent(_testData, result);
+        }
+
+        [Test]
+        public void IsEqual_SearchOnePropertyForMatchingNumber_ReturnsMatchingData()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Number).EqualTo(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number == 2));
+        }
+
+        [Test]
+        public void IsEqual_SearchTwoValues_ReturnsMatchingDataOnly()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Number).EqualTo(2, 4);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number == 2 || x.Number == 4));
+        }
+
+        [Test]
+        public void IsEqual_SearchTwoProperties_ReturnsMatchingDataOnly()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Number, x => x.Age).EqualTo(5);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number == 5 || x.Age == 5));
+        }
+
+        [Test]
+        public void GreaterThan_SearchOneProperty_ReturnsOnlyDataWherePropertyIsGreaterThanValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number).GreaterThan(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number > 2));
+        }
+
+        [Test]
+        public void GreaterThan_SearchTwoProperties_ReturnsOnlyDataWherePropertyIsGreaterThanValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number, x => x.Age).GreaterThan(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number > 2 || x.Age > 2));
+        }
+
+        [Test]
+        public void LessThan_SearchOneProperty_ReturnsOnlyDataWherePropertyIsLessThanValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number).LessThan(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number < 2));
+        }
+
+        [Test]
+        public void LessThan_SearchTwoProperties_ReturnsOnlyDataWhereEitherPropertyIsLessThanValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number, x => x.Age).LessThan(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number < 2 || x.Age < 2));
+        }
+
+        [Test]
+        public void LessThanOrEqual_SearchOneProperty_ReturnsOnlyDataWherePropertyIsLessThanOrEqualToValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number).LessThanOrEqualTo(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number <= 2));
+        }
+
+        [Test]
+        public void LessThanOrEqual_SearchTwoProperties_ReturnsOnlyDataWhereEitherPropertyIsLessThanOrEqualToValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number, x => x.Age).LessThanOrEqualTo(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number <= 2 || x.Age <= 2));
+        }
+
+        [Test]
+        public void GreaterThanOrEqual_SearchOneProperty_ReturnsOnlyDataWherePropertyIsGreaterThanOrEqualToValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number).GreaterThanOrEqualTo(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number >= 2));
+        }
+
+        [Test]
+        public void GreaterThanOrEqual_SearchTwoProperties_ReturnsOnlyDataWhereEitherPropertyIsGreaterThanOrEqualToValue()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Number, x => x.Age).GreaterThanOrEqualTo(2);
+
+            ////Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number >= 2 || x.Age >= 2));
+        }
+
+        [Test]
+        public void GreaterThanOrLessThan_SearchOnePropertyBetweenTwoValues_OnlyRecordsBetweenValuesReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Number)
+                                      .GreaterThan(2)
+                                      .LessThan(4);
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Number > 2 && x.Number < 4));
+        }
+
+        [Test]
+        public void Between_SearchTwoPropertiesBetweenTwoValues_OnlyRecordsBetweenValuesReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Number, x => x.Age)
+                                      .Between(2, 6);
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => (x.Number > 2 && x.Number < 6)
+                                       || (x.Age > 2 && x.Age < 6)));
+        }
+
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/IsEqualTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/IsEqualTests.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class IsEqualTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData {Name = "abcd", Description = "efgh", Status = "status"});
+            _testData.Add(new TestData {Name = "match", Description = "match", Status = "status"});
+            _testData.Add(new TestData {Name = "match", Description = "status", Status = "status"});
+            _testData.Add(new TestData {Name = "status", Description = "test", Status = "status"});
+            _testData.Add(new TestData {Name = "TEst", Description = "teST", Status = "case"});
+        }
+
+        [Test]
+        public void IsEqual_CallWithProperty_DoesNotThrowAnException()
+        {
+            //Arrange
+            
+            //Act
+
+            //Assert
+            Assert.DoesNotThrow(() => _testData.Search(x => x.Name).EqualTo(x => x.Description));
+        }
+
+        [Test]
+        public void IsEqual_CallWithProperty_DoesNotReturnNull()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).EqualTo(x => x.Description);
+
+            //Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void IsEqual_CallWithProperty_OnlyMatchingDataReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).EqualTo(x => x.Description);
+
+            //Assert
+            Assert.IsTrue(result.Any());
+            Assert.IsTrue(result.All(x => x.Name == x.Description));
+        }
+
+        [Test]
+        public void IsEqual_CompareTwoProperties_RecordsForSecondPropertyMatchReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).EqualTo(x => x.Status);
+
+            //Assert
+            Assert.IsTrue(result.Any(x => x.Description == x.Status));
+        }
+
+        [Test]
+        public void IsEqual_CompareAgainstTwoProperties_RecordsForSecondPropertyMatchReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).EqualTo(x => x.Description, x => x.Status);
+
+            //Assert
+            Assert.IsTrue(result.Any(x => x.Name == x.Status));
+        }
+
+        [Test]
+        public void IsEqual_SetCultureToIgnoreCase_MatchedRecordsOfDifferentCaseReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name).SetCulture(StringComparison.OrdinalIgnoreCase)
+                                                     .EqualTo(x => x.Description);
+
+            //Assert
+            Assert.IsTrue(result.Any(x => x.Name == "TEst" && x.Description == "teST"));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/LevenshteinSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/LevenshteinSearch.cs
@@ -1,0 +1,173 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Levenshtein;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class LevenshteinSearch
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData {Name = "use", Description = "cdef"});
+            _testData.Add(new TestData {Name = "house", Description = "mouse"});
+            _testData.Add(new TestData {Name = "mouse", Description = "desc"});
+            _testData.Add(new TestData {Name = "test", Description = "house"});
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistance_AllResultsReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(string.Empty)
+                                 .ToList();
+
+            //Assert
+            Assert.AreEqual(_testData.Count, result.Count);
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistance_ResultsOfTypeILevenshteinDistance()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(string.Empty)
+                                 .ToList();
+
+            //Assert
+            Assert.IsInstanceOf<IEnumerable<ILevenshteinDistance<TestData>>>(result);
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceAgainstEmptyString_DistanceOfFirstItemIsEqualToSourceLength()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(string.Empty)
+                                 .Take(1)
+                                 .ToList();
+
+            //Assert
+            Assert.AreEqual(result[0].Item.Name.Length, result[0].Distance);
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceAgainstEmptyString_DistanceOfSecondItemIsEqualToSourceLength()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(string.Empty)
+                                 .Skip(1)
+                                 .Take(1)
+                                 .ToList();
+
+            //Assert
+            Assert.AreEqual(result[0].Item.Name.Length, result[0].Distance);
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceAgainstEmptyString_AllDistancesAreEqualToSourceLength()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(string.Empty)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Distance == x.Item.Name.Length));
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceAgainstDefinedString_DistanceIsLevenshteinDistance()
+        {
+            //Arrange
+            const string compareTo = "choose";
+
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(compareTo)                               
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Distance == LevenshteinProcessor.LevenshteinDistance(x.Item.Name, compareTo)));
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceWithoutProperty_ThrowArgumentNullException()
+        {
+            //Arrange
+
+            //Act
+
+            //Assert
+            Assert.Throws<ArgumentNullException>(() => _testData.LevenshteinDistanceOf(null));
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceCompareTo_IncompleteRequestException()
+        {
+            //Arrange
+
+            //Act
+
+            //Assert
+            Assert.Throws<InvalidOperationException>(() => _testData.LevenshteinDistanceOf(x => x.Name).ToList());
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceAgainstDefinedProperty_DistanceIsLevenshteinDistance()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(x => x.Description)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Distance == LevenshteinProcessor.LevenshteinDistance(x.Item.Name, x.Item.Description)));
+        }
+
+        [Test]
+        public void Levenshtein_GetLevenshteinDistanceAgainstMultipleDefinedProperties_DistanceIsLevenshteinDistance()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.LevenshteinDistanceOf(x => x.Name)
+                                 .ComparedTo(x => x.Description)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Distance == LevenshteinProcessor.LevenshteinDistance(x.Item.Name, x.Item.Description)));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/SearchChildrenChaingingTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/SearchChildrenChaingingTests.cs
@@ -1,0 +1,109 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class SearchChildrenChaingingTests
+    {
+        private ParentTestData _parent;
+        private List<ParentTestData> _testData;
+        private TestData _dataOne;
+        private TestData _dataFour;
+        private TestData _dataTwo;
+        private TestData _dataThree;
+        private ParentTestData _otherParent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dataOne = new TestData {Name = "chris", Description = "child data", Number = 1, Age = 60};
+            _dataTwo = new TestData {Name = "fred", Description = "child", Number = 20, Age = 30};
+            _dataThree = new TestData {Name = "teddy", Description = "data", Number = 2, Age = 40};
+            _dataFour = new TestData {Name = "josh", Description = "child data", Number = 20, Age = 50};
+            _parent = new ParentTestData
+            {
+                Children = new List<TestData> {_dataOne, _dataTwo},
+            };
+            _otherParent = new ParentTestData
+            {
+                Children = new List<TestData> {_dataThree, _dataFour},
+            };
+            _testData = new List<ParentTestData> {_parent, _otherParent};
+        }
+
+        [Test]
+        public void SearchChildren_SearchStringAndInteger_ResultsMatchBothOccurences()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(x => x.Children)
+                                            .With(c => c.Name)
+                                            .Containing("ed")
+                                            .With(c => c.Number)
+                                            .EqualTo(20)
+                                            .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            CollectionAssert.Contains(result, _parent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchStringAndString_ResultsMatchBothOccurences()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(x => x.Children)
+                                            .With(c => c.Name)
+                                            .Containing("ed")
+                                            .With(c => c.Description)
+                                            .Containing("child")
+                                            .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            CollectionAssert.Contains(result, _parent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchIntegerAndString_ResultsMatchBothOccurences()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(x => x.Children)
+                                            .With(c => c.Number)
+                                            .EqualTo(20)
+                                            .With(c => c.Name)
+                                            .Containing("ed")
+                                            .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            CollectionAssert.Contains(result, _parent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchIntegerAndInteger_ResultsMatchBothOccurences()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(x => x.Children)
+                                            .With(c => c.Number)
+                                            .EqualTo(20)
+                                            .With(c => c.Age)
+                                            .GreaterThan(40)
+                                            .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            CollectionAssert.Contains(result, _otherParent);
+        }
+        
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/SearchChildrenForStringTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/SearchChildrenForStringTests.cs
@@ -1,0 +1,220 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class SearchChildrenForStringTests
+    {
+        private ParentTestData _parent;
+        private List<ParentTestData> _testData;
+        private TestData _dataOne;
+        private TestData _dataFour;
+        private TestData _dataTwo;
+        private TestData _dataThree;
+        private ParentTestData _otherParent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dataOne = new TestData {Name = "chris", Description = "child data", Number = 1, Age = 20};
+            _dataTwo = new TestData {Name = "fred", Description = "nested positionly", Number = 6, Age = 30};
+            _dataThree = new TestData {Name = "teddy", Description = "children description", Number = 2, Age = 40};
+            _dataFour = new TestData {Name = "josh", Description = "nested data", Number = 20, Age = 50};
+            _parent = new ParentTestData
+            {
+                Children = new List<TestData> {_dataOne, _dataTwo},
+            };
+            _otherParent = new ParentTestData
+            {
+                Children = new List<TestData> {_dataThree, _dataFour},
+            };
+            _testData = new List<ParentTestData> {_parent, _otherParent};
+        }
+
+        [Test]
+        public void SearchChild_StringEquals_ReturnParentsWIthAnyChildThatMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Name)
+                                  .EqualTo("chris")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_parent));
+        }
+
+        [Test]
+        public void SearchChild_StringEqualsMany_ReturnParentsWIthAnyChildThatMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Name)
+                                  .EqualTo("chris", "teddy")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result, Contains.Item(_parent));
+            Assert.That(result, Contains.Item(_otherParent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringEqualToCaseInsensitive_ReturnParentsWithMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Name)
+                                  .SetCulture(StringComparison.OrdinalIgnoreCase)
+                                  .EqualTo("CHRIS")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_parent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringContaining_ReturnParentsWithMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Name)
+                                  .Containing("ed")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result, Contains.Item(_parent));
+            Assert.That(result, Contains.Item(_otherParent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringContaining_IgnoresEmptyStrings()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Name)
+                                  .Containing("chris", "")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_parent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringContainingNoValidSearchTerms_ReturnsAll()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Name)
+                                  .Containing("")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result, Contains.Item(_parent));
+            Assert.That(result, Contains.Item(_otherParent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringContainingWholeWordSearch_ReturnsOnlyMatchesOfEntireWord()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Description)
+                                  .Matching(SearchType.WholeWords)
+                                  .Containing("child")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_parent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringContainingAnyOccurenceSearch_ReturnsAllMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Description)
+                                  .Matching(SearchType.AnyOccurrence)
+                                  .Containing("child")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(2));
+            Assert.That(result, Contains.Item(_parent));
+            Assert.That(result, Contains.Item(_otherParent));
+        }
+
+        [Test]
+        public void SearchChild_WithStringContainingAllSuppliedWords_ReturnsAllMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Description)
+                                  .ContainingAll("child", "data")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_parent));
+        }
+
+        [Test]
+        public void SearchChild_StringStartsWith_ReturnsAllMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Description)
+                                  .StartsWith("children")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_otherParent));
+        }
+
+        [Test]
+        public void SearchChild_StringEndsWith_ReturnsAllMatches()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                  .With(c => c.Description)
+                                  .EndsWith("tion")
+                                  .ToList();
+
+            //Assert
+            Assert.That(result.Count, Is.EqualTo(1));
+            Assert.That(result, Contains.Item(_otherParent));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/SearchChildrenTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/SearchChildrenTests.cs
@@ -1,0 +1,252 @@
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class SearchChildrenTests
+    {
+        private ParentTestData _parent;
+        private List<ParentTestData> _testData;
+        private TestData _dataOne;
+        private TestData _dataFour;
+        private TestData _dataTwo;
+        private TestData _dataThree;
+        private ParentTestData _otherParent;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _dataOne = new TestData { Name = "chris", Description = "child data", Number = 1, Age = 20};
+            _dataTwo = new TestData { Name = "fred", Description = "child data", Number = 6, Age = 30 };
+            _dataThree = new TestData { Name = "teddy", Description = "child data", Number = 2, Age = 40 };
+            _dataFour = new TestData { Name = "josh", Description = "child data", Number = 20, Age = 50 };
+            _parent = new ParentTestData
+            {
+                Children = new List<TestData> {_dataOne, _dataTwo},
+                OtherChildren = new List<TestData> { _dataThree, _dataFour }
+            };
+            _otherParent = new ParentTestData
+            {
+                Children = new List<TestData> {_dataThree, _dataFour},
+                OtherChildren = new List<TestData> { _dataOne, _dataTwo }
+            };
+            _testData = new List<ParentTestData> { _parent, _otherParent };            
+        }
+
+        [Test]
+        public void SearchChild_SearchChildCollectionWithoutProperty_ReturnParent()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(p => p.Children);
+
+            //Assert
+            CollectionAssert.AreEqual(_testData, result);
+        }
+
+        [Test]
+        public void SearchChild_SearchChildCollection_ReturnOnlyParentWhosChildNumberIsGreaterThanTen()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .GreaterThan(10)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(1));
+            Assert.That(result.All(p => p.Children.Any(c => c.Number > 10)), Is.True);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyGreaterThan()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .GreaterThan(4)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+            Assert.That(result.All(p => p.Children.Any(c => c.Number > 4)), Is.True);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyGreaterThanOrEqualTo()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .GreaterThanOrEqualTo(6)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+            Assert.That(result.All(p => p.Children.Any(c => c.Number >= 6)), Is.True);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyLessThan()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .LessThan(2)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(1));
+            CollectionAssert.Contains(result, _parent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyLessThanOrEqualTo()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .LessThanOrEqualTo(2)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyLessThanAndGreaterThan()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .LessThan(10)
+                                       .GreaterThan(2)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(1));
+            CollectionAssert.Contains(result, _parent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyBetween()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .Between(2, 10)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(1));
+            CollectionAssert.Contains(result, _parent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyEqualTo()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .EqualTo(2)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(1));
+            CollectionAssert.Contains(result, _otherParent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithPropertyEqualToAnyOneOfMultiple()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number)
+                                       .EqualTo(2, 6)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchChildCollectionWithMultiplePropertiesEqualTo()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.SearchChildren(p => p.Children)
+                                       .With(c => c.Number, c => c.Age)
+                                       .EqualTo(20)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchMultipleChildCollectionsWithPropertyEqualTo()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(p => p.Children, p => p.OtherChildren)
+                                       .With(c => c.Number)
+                                       .EqualTo(20)
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+        }
+
+        [Test]
+        public void SearchChildren_SearchMultipleChildCollectionsWithStringPropertyEqualTo()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.SearchChildren(p => p.Children, p => p.OtherChildren)
+                                       .With(c => c.Name)
+                                       .EqualTo("chris")
+                                       .ToList();
+
+            //Assert
+            Assert.That(result.Count(), Is.EqualTo(2));
+            CollectionAssert.Contains(result, _parent);
+            CollectionAssert.Contains(result, _otherParent);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/StartsWithTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/StartsWithTests.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class StartsWithTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Status = "status" });
+            _testData.Add(new TestData { Name = "mnop", Description = "m", Status = "status" });
+            _testData.Add(new TestData { Name = "yesterday", Description = "no", Status = "yes" });
+            _testData.Add(new TestData { Name = "another day", Description = "null status" });
+            _testData.Add(new TestData { Name = "test", Description = "description", Status = "desc" });
+            _testData.Add(new TestData { Name = "teSt cAsE iNsEnSiTiViTy", Description = "TEsT" });
+        }
+
+        [Test]
+        public void StartsWith_ComparedToAnExistingProperty_DoesNotThrowAnException()
+        {
+            //Arrange
+
+            //Act
+            //Assert
+            Assert.DoesNotThrow(() => _testData.Search(x => x.Name).StartsWith(x => x.Description));
+        }
+
+        [Test]
+        public void StartsWith_ComparedToAnExistingProperty_ResultIsNotNull()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).StartsWith(x => x.Description);
+
+            //Assert
+            Assert.IsNotNull(result);
+        }
+
+        [Test]
+        public void StartsWith_ComparedToAnExistingProperty_ResultStartsWithExistingProperty()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).StartsWith(x => x.Description);
+
+            //Assert
+            Assert.IsTrue(result.Any(), "No records returned");
+            Assert.IsTrue(result.All(x => x.Name.StartsWith(x.Description)));
+        }
+
+        [Test]
+        public void StartsWith_ComparedToTwoExistingProperties_ResultStartsWithEitherOfExistingProperties()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).StartsWith(x => x.Description, x => x.Status);
+
+            //Assert
+            Assert.IsTrue(result.Any(), "No records returned");
+            Assert.IsTrue(result.All(x => x.Name.StartsWith(x.Description) || x.Name.StartsWith(x.Status)));
+        }
+
+        [Test]
+        public void StartsWith_ComparedToTwoExistingPropertiesWithNullValue_NullValueIsIgnored()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).StartsWith(x => x.Description, x => x.Status);
+
+            //Assert
+            Assert.IsTrue(result.Any(), "No records returned");
+            Assert.IsTrue(result.All(x => x.Name.StartsWith(x.Description) || (x.Status != null && x.Name.StartsWith(x.Status))));
+        }
+
+        [Test]
+        public void StartsWith_SearchTwoPropertiesComparedToAProperty_ResultsContainAllPermiatations()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description).StartsWith(x => x.Status);
+
+            //Assert
+            Assert.IsTrue(result.Count() > 1, "Not enough records returned");
+            Assert.IsTrue(result.All(x => x.Name.StartsWith(x.Status) || x.Description.StartsWith(x.Status)));
+        }
+
+        [Test]
+        public void StartsWith_SearchPropertyWithIgnoreCaseCulture_ResultsAreCaseInsensitive()
+        {
+            //Arrange
+
+            //Act
+            var result = _testData.Search(x => x.Name).SetCulture(StringComparison.OrdinalIgnoreCase).StartsWith(x => x.Description);
+
+            //Assert
+            Assert.IsTrue(result.Any(t => t.Description == "TEsT"));
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/StringSearchTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/IEnumerableTests/StringSearchTests.cs
@@ -1,0 +1,188 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests.IEnumerableTests
+{
+    [TestFixture]
+    public class StringSearchTests
+    {
+        private List<TestData> _testData = new List<TestData>();
+
+        [SetUp]
+        public void ClassSetup()
+        {
+            _testData = new List<TestData>();
+            BuildTestData();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _testData.Clear();
+        }
+
+        private void BuildTestData()
+        {
+            _testData.Add(new TestData { Name = "abcd", Description = "efgh", Number = 1 });
+            _testData.Add(new TestData { Name = "ijkl", Description = "mnop", Number = 2 });
+            _testData.Add(new TestData { Name = "qrst", Description = "uvwx", Number = 3 });
+            _testData.Add(new TestData { Name = "yzab", Description = "cdef", Number = 4 });
+        }
+
+        [Test]
+        public void Search_SearchTermNotSupplied_AllDataReturned()
+        {
+            //Arrange
+            
+            //Act
+            var result = _testData.Search(x => x.Name);
+
+            //Assert
+            Assert.AreEqual(_testData, result);
+        }
+
+        [Test]
+        public void Search_SearchAParticularProperty_OnlyResultsWithAMatchAreReturned()
+        {
+            //Arrange
+            const string searchTerm = "cd";
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing(searchTerm).ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm)));
+        }
+
+        [Test]
+        public void Search_SearchAParticularPropertyWithMultipleTerms_OnlyResultsWithAMatchAreReturned()
+        {
+            //Arrange
+            const string searchTerm1 = "cd";
+            const string searchTerm2 = "jk";
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing(searchTerm1, searchTerm2).ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm1) || x.Name.Contains(searchTerm2)));
+        }
+
+        [Test]
+        public void Search_SearchForATermWithMultipleProperties_OnlyResultsWithAMatchAreReturned()
+        {
+            //Arrange
+            const string searchTerm = "cd";
+            
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description)
+                                 .Containing(searchTerm)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm) || x.Description.Contains(searchTerm)));
+        }
+
+        [Test]
+        public void Search_SearchForMultipleTermsWithMultipleProperties_OnlyResultsWithAMatchAreReturned()
+        {
+            //Arrange
+            const string searchTerm1 = "cd";
+            const string searchTerm2 = "uv";
+
+            //Act
+            var result = _testData.Search(x => x.Name, x => x.Description)
+                                 .Containing(searchTerm1, searchTerm2)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm1) 
+                                       || x.Name.Contains(searchTerm2)
+                                       || x.Description.Contains(searchTerm1) 
+                                       || x.Description.Contains(searchTerm2)));
+        }
+
+        [Test]
+        public void Search_SearchForAnUppercaseTermIgnoringCase_StringComparisonIsRespected()
+        {
+            //Arrange
+            const string searchTerm = "CD";
+
+            //Act
+            var result = _testData.Search(x => x.Name)
+                                 .SetCulture(StringComparison.InvariantCultureIgnoreCase)
+                                 .Containing(searchTerm)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm.ToLower())));
+        }
+
+        [Test]
+        public void Search_SearchForAnUppercaseTermRespectingCase_OnlyMatchingResultsAreReturned()
+        {
+            //Arrange
+            const string searchTerm = "CD";
+            _testData.Add(new TestData { Name = searchTerm });
+
+            //Act
+            var result = _testData.Search(x => x.Name)
+                                 .SetCulture(StringComparison.Ordinal)
+                                 .Containing(searchTerm)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm)));
+        }
+
+        [Test]
+        public void Search_SearchWithoutProperties_AllPropertiesSearched()
+        {
+            //Arrange
+            const string searchTerm = "cd";
+            
+            //Act
+            var result = _testData.Search().Containing(searchTerm);
+
+            //Assert
+            Assert.AreEqual(2, result.Count());
+        }
+
+        [Test]
+        public void Search_SearchAllPropertiesIgnoreCase_MatchesMadeRegardlessOfCase()
+        {
+            //Arrange
+            const string searchTerm = "CD";
+            _testData.Add(new TestData { Name = searchTerm, Description = "test"});
+            _testData.Add(new TestData { Name = "test", Description = searchTerm });
+            
+            //Act
+            var result = _testData.Search()
+                                 .SetCulture(StringComparison.OrdinalIgnoreCase)
+                                 .Containing(searchTerm)
+                                 .ToList();
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.IndexOf(searchTerm, StringComparison.OrdinalIgnoreCase) > -1
+                                       || x.Description.IndexOf(searchTerm, StringComparison.OrdinalIgnoreCase) > -1 ));
+        }
+
+        [Test]
+        public void Search_PerformANDSearchAcrossTwoProperties_MatchesOnlyWhereBothAreTrue()
+        {
+            //Arrange
+            const string searchTerm1 = "ab";
+            const string searchTerm2 = "ef";
+            
+            //Act
+            var result = _testData.Search(x => x.Name).Containing(searchTerm1)
+                                 .Search(x => x.Description).Containing(searchTerm2);
+
+            //Assert
+            Assert.IsTrue(result.All(x => x.Name.Contains(searchTerm1) && x.Description.Contains(searchTerm2)));
+
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/TestData.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SearchExtensionTests/TestData.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SearchExtensionTests
+{
+    internal class ParentTestData
+    {
+        public ICollection<TestData> Children { get; set; }
+        public IEnumerable<TestData> OtherChildren { get; set; }
+    }
+
+    internal class TestData
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Status { get; set; }
+        public int Number { get; set; }
+        public int Age { get; set; }
+        public DateTime Start { get; set; }
+        public DateTime End { get; set; }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ReverseSoundexPerformanceTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ReverseSoundexPerformanceTests.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Soundex;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SoundexTests
+{
+#if DEBUG
+    [Ignore("Performance tests only to be run in Release mode")]
+#endif
+    [TestFixture]
+    public class  ReverseSoundexPerformanceTests : BuildStringTestsBase
+    {
+        [Test]
+        public void ToReverseSoundex_OneMillionRecords_UnderOneSecond()
+        {
+            //Arrange
+            var words = BuildWords(1000000);
+            Console.WriteLine("Processing {0} words", words.Count);
+            var stopwatch = new Stopwatch();
+            Console.WriteLine("Begin soundex...");
+            stopwatch.Start();
+
+            //Act
+            var result = words.Select(SoundexProcessor.ToReverseSoundex).ToList();
+            stopwatch.Stop();
+            Console.WriteLine("Time taken: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Results retrieved: {0}", result.Count());
+            //Assert
+            Assert.True(stopwatch.Elapsed.TotalMilliseconds < 1000);
+        }
+
+        [Test]
+        public void ReverseSoundex_ReverseWordSoundexVsToReverseSoundex_ToReverseSoundexIsQuicker()
+        {
+            //Arrange
+            var words = BuildWords(1000000);
+            Console.WriteLine("Processing {0} words", words.Count);
+
+            var stopwatch = new Stopwatch();
+            Console.WriteLine("Begin reverse soundex search...");
+            stopwatch.Start();
+            var reverseWordResult = words.Select(w => w.Reverse().ToString().ToSoundex()).ToList();
+
+            //Act
+
+            stopwatch.Stop();
+            var reverseSoundexTimeTaken = stopwatch.Elapsed;
+            Console.WriteLine("Time taken: {0}", reverseSoundexTimeTaken);
+            Console.WriteLine("Results retrieved: {0}", reverseWordResult.Count);
+
+            Console.WriteLine("Begin reverse word ToSoundex search...");
+            stopwatch.Restart();
+            var reverseSoundexResult = words.Select(w => w.ToReverseSoundex()).ToList();
+            stopwatch.Stop();
+            var reverseWordTimeTaken = stopwatch.Elapsed;
+            Console.WriteLine("Time taken: {0}", reverseWordTimeTaken);
+            Console.WriteLine("Results retrieved: {0}", reverseSoundexResult.Count);
+
+            //Assert
+            Assert.True(reverseWordTimeTaken < reverseSoundexTimeTaken);
+        }
+
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ToReverseSoundexTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ToReverseSoundexTests.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SoundexTests
+{
+    [TestFixture]
+    public class ToReverseSoundexTests
+    {
+        [Test]
+        public void ToReverseSoundex_EmptyStringProvided_EmptyStringReturned()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToReverseSoundex("");
+
+            //Assert
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void ToReverseSoundex_NonEmptyStringProvided_NonEmptyStringReturned()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToReverseSoundex("test");
+
+            //Assert
+            Assert.IsNotEmpty(result);
+        }
+
+        [Test]
+        public void ToReverseSoundex_NonEmptyStringProvided_ReturnedStringStartsWithLastLetterInUpperCase()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToReverseSoundex("Tester");
+
+            //Assert
+            Assert.AreEqual('R', result[0]);
+        }
+
+
+        [TestCase("umberella", "A461")]
+        [TestCase("apple", "E410")]
+        [TestCase("perreli", "I461")]
+        [TestCase("indigo", "O235")]
+        [TestCase("zulu", "U420")]
+        public void ToReverseSoundex_LastLetterIsAVowell_LastLetterIsNotRemoved(string value, string expected)
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToReverseSoundex(value).ToUpper();
+
+            //Assert
+            Assert.AreEqual(expected, result);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ToSoundexPerformanceTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ToSoundexPerformanceTests.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using NinjaNye.SearchExtensions.Portable.Soundex;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SoundexTests
+{
+#if DEBUG
+    [Ignore("Performance tests only to be run in Release mode")]
+#endif
+    [TestFixture]
+    public class ToSoundexPerformanceTests : BuildStringTestsBase
+    {
+        [Test]
+        public void ToSoundex_OneMillionRecords_UnderOneSecond()
+        {
+            //Arrange
+            var words = BuildWords(1000000);
+            Console.WriteLine("Processing {0} words", words.Count);
+            var stopwatch = new Stopwatch();
+            Console.WriteLine("Begin soundex...");
+            stopwatch.Start();
+             
+            //Act
+            var result = words.Select(SoundexProcessor.ToSoundex).ToList();
+            stopwatch.Stop();
+            Console.WriteLine("Time taken: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Results retrieved: {0}", result.Count()); 
+            //Assert
+            Assert.True(stopwatch.Elapsed.TotalMilliseconds < 1000);
+        }
+
+        [Test]
+        public void SearchSoundex_OneMillionWordsComparedToOneWord_UnderOneSecond()
+        {
+            //Arrange
+            var words = BuildWords(1000000);
+            Console.WriteLine("Processing {0} words", words.Count);
+            
+            var stopwatch = new Stopwatch();
+            Console.WriteLine("Begin soundex search...");
+            stopwatch.Start();
+             
+            //Act
+            var result = words.Search(x => x).Soundex("test").ToList();
+            stopwatch.Stop();
+            Console.WriteLine("Time taken: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Results retrieved: {0}", result.Count);
+            //Assert
+            Assert.True(stopwatch.Elapsed.TotalMilliseconds < 1000);
+        }
+
+        [Test]
+        public void SearchSoundex_OneMillionWordsComparedToTwoWords_UnderOneSecond()
+        {
+            //Arrange
+            var words = BuildWords(1000000);
+            Console.WriteLine("Processing {0} words", words.Count);
+
+            var stopwatch = new Stopwatch();
+            Console.WriteLine("Begin soundex search...");
+            stopwatch.Start();
+
+            //Act
+            var result = words.Search(x => x).Soundex("test", "bacon").ToList();
+            stopwatch.Stop();
+            Console.WriteLine("Time taken: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Results retrieved: {0}", result.Count);
+            //Assert
+            Assert.True(stopwatch.Elapsed.TotalMilliseconds < 1000);
+        }
+
+        [Test]
+        public void SearchSoundex_OneMillionWordsComparedToTenWords_UnderOneSecond()
+        {
+            //Arrange
+            var words = BuildWords(1000000);
+            Console.WriteLine("Processing {0} words", words.Count);
+
+            var stopwatch = new Stopwatch();
+            Console.WriteLine("Begin soundex search...");
+            stopwatch.Start();
+
+            //Act
+            var result = words.Search(x => x).Soundex("historians", "often", "articulate", "great", "battles",
+                                                      "elegantly", "without", "pause", "for", "thought").ToList();
+            stopwatch.Stop();
+            Console.WriteLine("Time taken: {0}", stopwatch.Elapsed);
+            Console.WriteLine("Results retrieved: {0}", result.Count);
+            //Assert
+            Assert.True(stopwatch.Elapsed.TotalMilliseconds < 1000);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ToSoundexTests.cs
+++ b/NinjaNye.SearchExtensions.Portable.Tests/SoundexTests/ToSoundexTests.cs
@@ -1,0 +1,632 @@
+﻿using NUnit.Framework;
+
+namespace NinjaNye.SearchExtensions.Portable.Tests.SoundexTests
+{
+    [TestFixture]
+    public class ToSoundexTests
+    {
+        [Test]
+        public void ToSoundex_EmptyStringProvided_EmptyStringReturned()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("");
+
+            //Assert
+            Assert.IsEmpty(result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_NonEmptyStringReturned()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("test");
+
+            //Assert
+            Assert.IsNotEmpty(result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringStartsWithSameUpperCaseLetter()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Test");
+
+            //Assert
+            Assert.AreEqual('T', result[0]);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoACharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Bats");
+
+            //Assert
+            Assert.AreEqual("B320", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseACharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("BATS");
+
+            //Assert
+            Assert.AreEqual("B320", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoECharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Breeze");
+
+            //Assert
+            Assert.AreEqual("B620", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseECharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("BREEZE");
+
+            //Assert
+            Assert.AreEqual("B620", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoICharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Brick");
+
+            //Assert
+            Assert.AreEqual("B620", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseICharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("BRICK");
+
+            //Assert
+            Assert.AreEqual("B620", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Hunt");
+
+            //Assert
+            Assert.AreEqual("H530", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseUCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("HUNT");
+
+            //Assert
+            Assert.AreEqual("H530", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoYCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Bayern");
+
+            //Assert
+            Assert.AreEqual("B650", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseYCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("BAYERN");
+
+            //Assert
+            Assert.AreEqual("B650", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoHCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Breathe");
+
+            //Assert
+            Assert.AreEqual("B630", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseHCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("BREATHE");
+
+            //Assert
+            Assert.AreEqual("B630", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoWCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Qwerty");
+
+            //Assert
+            Assert.AreEqual("Q630", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseWCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("QWERTY");
+
+            //Assert
+            Assert.AreEqual("Q630", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoOCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Broom");
+
+            //Assert
+            Assert.AreEqual("B650", result);
+        }
+
+        [Test]
+        public void ToSoundex_NonEmptyStringProvided_ReturnedStringHasNoUppercaseOCharacters()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("BROOM");
+
+            //Assert
+            Assert.AreEqual("B650", result);
+        }
+
+        [TestCase("apple", "A140")]
+        [TestCase("elephant", "E415")]
+        [TestCase("indigo", "I532")]
+        [TestCase("orange", "O652")]
+        [TestCase("umbrella", "U516")]
+        public void ToSoundex_FirstLetterIsAVowell_FirstLetterIsNotRemoved(string value, string expected)
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex(value).ToUpper();
+
+            //Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceBWith1()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("ABCD");
+
+            //Assert
+            Assert.AreEqual("A123", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceFWith1()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("DEFG");
+
+            //Assert
+            Assert.AreEqual("D120", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplacePWith1()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("NOPQ");
+
+            //Assert
+            Assert.AreEqual("N120", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceVWith1()
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("TUVW");
+
+            //Assert
+            Assert.AreEqual("T100", result);
+        }
+
+        [TestCase("BCDE", "B230")]
+        [TestCase("FGHI", "F200")]
+        [TestCase("PQRS", "P262")]
+        [TestCase("VWXY", "V200")]
+        public void ToSoundex_NumberReplacements_FirstCharacterIsNotReplaced(string value, string expected)
+        {
+            //Arrange
+            
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex(value);
+
+            //Assert
+            Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceCWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("ABCD");
+
+            //Assert
+            Assert.AreEqual("A123", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceGWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("EFGH");
+
+            //Assert
+            Assert.AreEqual("E120", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceJWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("HIJK");
+
+            //Assert
+            Assert.AreEqual("H200", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceKWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("HIJK");
+
+            //Assert
+            Assert.AreEqual("H200", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceQWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("PQRS");
+
+            //Assert
+            Assert.AreEqual("P262", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceSWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("PQRS");
+
+            //Assert
+            Assert.AreEqual("P262", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceXWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("VWXY");
+
+            //Assert
+            Assert.AreEqual("V200", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplacezWith2()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("WXYZ");
+
+            //Assert
+            Assert.AreEqual("W220", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceDWith3()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("CDEF");
+
+            //Assert
+            Assert.AreEqual("C310", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceTWith3()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("RSTU");
+
+            //Assert
+            Assert.AreEqual("R230", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceLWith4()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("MNLO");
+
+            //Assert    
+            Assert.AreEqual("M400", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceTWith5()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("LMNO");
+
+            //Assert
+            Assert.AreEqual("L500", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceLWith5()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("LMNO");
+
+            //Assert
+            Assert.AreEqual("L500", result);
+        }
+
+        [Test]
+        public void ToSoundex_NumberReplacements_ReplaceLWith6()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("PQRS");
+
+            //Assert
+            Assert.AreEqual("P262", result);
+        }
+
+        [Test]
+        // If two or more letters with the same number are adjacent in the 
+        // original name (before step 1), only retain the first letter
+        public void ToSoundex_TwoMatchingLetterGroups_OnlyRetainOnce()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Flasker");
+
+            //Assert
+            Assert.AreEqual("F426", result);
+        }
+
+        [Test]
+        // If two or more letters with the same number are adjacent in the 
+        // original name (before step 1), only retain the first letter
+        public void ToSoundex_ThreeMatchingLetterGroups_OnlyRetainOnce()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Flasks");
+
+            //Assert
+            Assert.AreEqual("F420", result);
+        }
+
+        [Test]
+        // two letters with the same number separated by 'h' or 'w' are coded as a single number
+        public void ToSoundex_MatchingLetterGroupSeperatedByH_OnlyRetainOnce()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Ashcraft");
+
+            //Assert
+            Assert.AreEqual("A261", result);
+        }
+
+        [Test]
+        // letters separated by a vowel are coded twice
+        public void ToSoundex_MatchingLetterGroupSeperatedByVowell_RetainBoth()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Stadium");
+
+            //Assert
+            Assert.AreEqual("S335", result);
+        }
+
+        [Test]
+        // If two or more letters with the same number are adjacent in the 
+        // original name (before step 1), only retain the first letter
+        public void ToSoundex_TwoMatchingLetterGroupsAtStart_OnlyRetainOnce()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Pfister");
+
+            //Assert
+            Assert.AreEqual("P236", result);
+        }
+
+        [Test]
+        // If you have too few letters in your word that you can't assign 
+        // three numbers, append with zeros until there are three numbers
+        public void ToSoundex_TooFewNumbers_PadToThreeNumbers()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Rubin");
+
+            //Assert
+            Assert.AreEqual("R150", result);
+        }
+
+        [Test]
+        //  If you have more than 3 letters, just retain the first 3 numbers
+        public void ToSoundex_TooManyNumbers_TrimToThreeNumbers()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Ashcraft");
+
+            //Assert
+            Assert.AreEqual("A261", result);
+        }
+
+        [Test]
+        //  If you have more than 3 letters, just retain the first 3 numbers
+        public void ToSoundex_AnalyseRobertAndRupert_BothReturnTheSameCode()
+        {
+            //Arrange
+
+            //Act
+            string result1 = Soundex.SoundexProcessor.ToSoundex("Robert");
+            string result2 = Soundex.SoundexProcessor.ToSoundex("Rupert");
+
+            //Assert
+            Assert.AreEqual("R163", result1);
+            Assert.AreEqual(result1, result2);
+        }
+
+        [Test]
+        //  If you have more than 3 letters, just retain the first 3 numbers
+        public void ToSoundex_AnalyseAshcraftAndAshcroft_BothReturnTheSameCode()
+        {
+            //Arrange
+
+            //Act
+            string result1 = Soundex.SoundexProcessor.ToSoundex("Ashcraft");
+            string result2 = Soundex.SoundexProcessor.ToSoundex("Aschroft");
+
+            //Assert
+            Assert.AreEqual(result1, result2);
+        }
+
+        [Test]
+        //  If you have more than 3 letters, just retain the first 3 numbers
+        public void ToSoundex_AnalyseTymczak_ReturnCorrectCode()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("Tymczak");
+
+            //Assert
+            Assert.AreEqual("T522", result);
+        }
+
+        [Test]
+        public void ToSoundex_LowercaseWord_ReturnUppercaseCode()
+        {
+            //Arrange
+
+            //Act
+            string result = Soundex.SoundexProcessor.ToSoundex("ashcraft");
+
+            //Assert
+            Assert.AreEqual("A261", result);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable.Tests/packages.config
+++ b/NinjaNye.SearchExtensions.Portable.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="NUnitTestAdapter" version="2.0.0" targetFramework="net452" />
+</packages>

--- a/NinjaNye.SearchExtensions.Portable/ChildSearchBase.cs
+++ b/NinjaNye.SearchExtensions.Portable/ChildSearchBase.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+using NinjaNye.SearchExtensions.Portable.Visitors;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class ChildSearchBase<TParent, TChild, TProperty>
+    {
+        protected Expression<Func<TParent, IEnumerable<TChild>>>[] _childProperties;
+        protected Expression<Func<TChild, TProperty>>[] Properties;
+        private ParameterExpression _parentParameter;
+        protected ParameterExpression _childParameter = Expression.Parameter(typeof(TChild), "child");
+        protected Expression _completeExpression;
+
+        protected ChildSearchBase(Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties, Expression completeExpression, ParameterExpression childParameter)
+        {
+            _parentParameter = childProperties[0].Parameters[0];
+            if (childParameter != null) _childParameter = childParameter;
+
+            _childProperties = AlignParameters(childProperties, _parentParameter).ToArray();
+            Properties = AlignParameters(properties, _childParameter).ToArray();
+            _completeExpression = completeExpression;
+        }
+
+        private IEnumerable<Expression<Func<TSource, TResult>>> AlignParameters<TSource, TResult>(Expression<Func<TSource, TResult>>[] properties, ParameterExpression parameterExpression)
+        {
+            for (int i = 0; i < properties.Length; i++)
+            {
+                var property = properties[i];
+                yield return SwapExpressionVisitor.Swap(property, property.Parameters.Single(), parameterExpression);
+            }
+        }
+
+        protected void AppendExpression(Expression equalToExpression)
+        {
+            _completeExpression = ExpressionHelper.JoinAndAlsoExpression(_completeExpression, equalToExpression);
+        }
+
+        protected Expression<Func<TParent, bool>> BuildFinalExpression()
+        {
+            if (_completeExpression == null)
+            {
+                return Expression.Lambda<Func<TParent, bool>>(Expression.Constant(true), _parentParameter);
+            }
+            var anyMethodInfo = ExpressionMethods.AnyQueryableMethod.MakeGenericMethod(typeof (TChild));
+            Expression finalExpression = null;
+            foreach (var childProperty in _childProperties)
+            {
+                var anyExpression = Expression.Lambda<Func<TChild, bool>>(_completeExpression, _childParameter);
+                var anyChild = Expression.Call(null, anyMethodInfo, childProperty.Body, anyExpression);
+                finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, anyChild);
+            }
+
+            var final = Expression.Lambda<Func<TParent, bool>>(finalExpression, _parentParameter);
+            return final;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableChildSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableChildSearch.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableChildSearch<TParent, TChild, TProperty> : EnumerableChildSearchBase<TParent, TChild, TProperty>
+    {
+        public EnumerableChildSearch(IEnumerable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties)
+            : base(parent, childProperties, properties, null, null)
+        {
+        }
+
+        public EnumerableChildSearch(IEnumerable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties, Expression completeExpression, ParameterExpression childParameter)
+            : base(parent, childProperties, properties, completeExpression, childParameter)
+        {
+        }
+
+        /// <summary>
+        /// Identifies items where any of the defined properties
+        /// are greater than any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableChildSearch<TParent, TChild, TProperty> GreaterThan(TProperty value)
+        {
+            var greaterThanExpression = ExpressionBuilder.GreaterThanExpression(Properties, value);
+            AppendExpression(greaterThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Identifies items where any of the defined properties
+        /// are greater than or equal to any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableChildSearch<TParent, TChild, TProperty> GreaterThanOrEqualTo(TProperty value)
+        {
+            var greaterThanExpression = ExpressionBuilder.GreaterThanOrEqualExpression(Properties, value);
+            AppendExpression(greaterThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Identifies items where any of the defined properties
+        /// are less than any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableChildSearch<TParent, TChild, TProperty> LessThan(TProperty value)
+        {
+            var lessThanExpression = ExpressionBuilder.LessThanExpression(Properties, value);
+            AppendExpression(lessThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Identifies items where any of the defined properties
+        /// are less than or equal to any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableChildSearch<TParent, TChild, TProperty> LessThanOrEqualTo(TProperty value)
+        {
+            var lessThanExpression = ExpressionBuilder.LessThanOrEqualExpression(Properties, value);
+            AppendExpression(lessThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than <paramref name="minValue">minValue</paramref> 
+        /// AND less than <paramref name="maxValue">maxValue</paramref> 
+        /// </summary>
+        public EnumerableChildSearch<TParent, TChild, TProperty> Between(TProperty minValue, TProperty maxValue)
+        {
+            var betweenExpression = ExpressionBuilder.BetweenExpression(Properties, minValue, maxValue);
+            AppendExpression(betweenExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are equal to any of the supplied <paramref name="values">value</paramref> 
+        /// </summary>
+        /// <param name="values">A collection of values to match upon</param>
+        public EnumerableChildSearch<TParent, TChild, TProperty> EqualTo(params TProperty[] values)
+        {
+            var equalToExpression = ExpressionBuilder.EqualsExpression(Properties, values);
+            AppendExpression(equalToExpression);
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableChildSearchBase.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableChildSearchBase.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableChildSearchBase<TParent, TChild, TProperty> : ChildSearchBase<TParent, TChild, TProperty>, IEnumerable<TParent>
+    {
+        private readonly IEnumerable<TParent> _parent;
+
+        protected EnumerableChildSearchBase(IEnumerable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties, Expression completeExpression, ParameterExpression childParameter)
+            : base(childProperties, properties, completeExpression, childParameter)
+        {
+            _parent = parent;
+        }
+
+        /// <summary>
+        /// Begin a search against a new property.
+        /// </summary>
+        public EnumerableChildSearch<TParent, TChild, TAnotherProperty> With<TAnotherProperty>(params Expression<Func<TChild, TAnotherProperty>>[] properties)
+        {
+            return new EnumerableChildSearch<TParent, TChild, TAnotherProperty>(_parent, _childProperties, properties, _completeExpression, _childParameter);
+        }
+
+        /// <summary>
+        /// Begin a search against a new string property.
+        /// </summary>
+        public EnumerableChildStringSearch<TParent, TChild> With(params Expression<Func<TChild, string>>[] properties)
+        {
+            return new EnumerableChildStringSearch<TParent, TChild>(_parent, _childProperties, properties, _completeExpression, _childParameter);
+        }
+
+        public IEnumerator<TParent> GetEnumerator()
+        {
+            var final = BuildFinalExpression().Compile();
+            return _parent.Where(final).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableChildSelector.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableChildSelector.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableChildSelector<TBase, TChild> : IEnumerable<TBase>
+    {
+        private readonly IEnumerable<TBase> _parent;
+        private readonly Expression<Func<TBase, IEnumerable<TChild>>>[] _childProperties;
+
+        public EnumerableChildSelector(IEnumerable<TBase> parent, Expression<Func<TBase, IEnumerable<TChild>>>[] childProperties) 
+        {
+            _parent = parent;
+            _childProperties = childProperties;
+        }
+
+        public EnumerableChildSearch<TBase, TChild, TProperty> With<TProperty>(params Expression<Func<TChild, TProperty>>[] properties)
+        {
+            return new EnumerableChildSearch<TBase, TChild, TProperty>(_parent, _childProperties, properties);
+        }
+
+        public EnumerableChildStringSearch<TBase, TChild> With(params Expression<Func<TChild, string>>[] properties)
+        {
+            return new EnumerableChildStringSearch<TBase, TChild>(_parent, _childProperties, properties);
+        }
+
+        public IEnumerator<TBase> GetEnumerator()
+        {
+            return _parent.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableChildStringSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableChildStringSearch.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.ContainsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableChildStringSearch<TParent, TChild> : EnumerableChildSearchBase<TParent, TChild, string>
+    {
+        private readonly SearchOptions _searchOptions = new SearchOptions();
+
+        public EnumerableChildStringSearch(IEnumerable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, string>>[] properties)
+            : base(parent, childProperties, properties, null, null)
+        {
+        }
+
+        public EnumerableChildStringSearch(IEnumerable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, string>>[] properties, Expression currentExpression, ParameterExpression childParameter) 
+            : base(parent, childProperties, properties, currentExpression, childParameter)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are equal to any of the supplied <paramref name="values">value</paramref> 
+        /// </summary>
+        /// <param name="values">A collection of values to match upon</param>
+        public EnumerableChildStringSearch<TParent, TChild> EqualTo(params string[] values)
+        {
+            var equalToExpression = EnumerableEqualsExpressionBuilder.Build(Properties, values, _searchOptions);
+            AppendExpression(equalToExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableChildStringSearch<TParent, TChild> Containing(params string[] terms)
+        {
+            var validSearchTerms = terms.Where(s => !String.IsNullOrWhiteSpace(s)).ToArray();
+            if (validSearchTerms.Any())
+            {
+                var containingExpression = EnumerableContainsExpressionBuilder.Build(Properties, validSearchTerms, _searchOptions);
+                AppendExpression(containingExpression);
+            }
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where all of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableChildStringSearch<TParent, TChild> ContainingAll(params string[] terms)
+        {
+            for (int i = 0; i < terms.Length; i++)
+            {
+                Containing(terms[i]);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties starts 
+        /// with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableChildStringSearch<TParent, TChild> StartsWith(params string[] terms)
+        {
+            Expression startsWithExpression = EnumerableStartsWithExpressionBuilder.Build(Properties, terms, _searchOptions);
+            AppendExpression(startsWithExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties starts 
+        /// with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableChildStringSearch<TParent, TChild> EndsWith(params string[] terms)
+        {
+            Expression endsWithExpression = EnumerableEndsWithExpressionBuilder.Build(Properties, terms, _searchOptions);
+            AppendExpression(endsWithExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Set the culture used for string comparisons
+        /// </summary>
+        public EnumerableChildStringSearch<TParent, TChild> SetCulture(StringComparison comparisonType)
+        {
+            _searchOptions.ComparisonType = comparisonType;
+            return this;
+        }
+
+        /// <summary>
+        /// Alter the matching algorithm between matching any occurence 
+        /// and matching whole words only
+        /// </summary>
+        public EnumerableChildStringSearch<TParent, TChild> Matching(SearchType searchType)
+        {
+            _searchOptions.SearchType = searchType;
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableLevenshteinCompare.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableLevenshteinCompare.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableLevenshteinCompare<T> : EnumerableSearchBase<T, string>
+    {
+        public EnumerableLevenshteinCompare(IEnumerable<T> source) 
+            : base(source, new Expression<Func<T, string>>[0])
+        {
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableLevenshteinSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableLevenshteinSearch.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+using NinjaNye.SearchExtensions.Portable.Levenshtein;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableLevenshteinSearch<T> : EnumerableSearchBase<T, string>
+    {
+        public EnumerableLevenshteinSearch(IEnumerable<T> source, Expression<Func<T, string>>[] stringProperties)
+            : base(source, stringProperties)
+        {
+        }
+
+        /// <summary>
+        /// Define the term with which to compare string properties to
+        /// </summary>
+        /// <param name="stringProperties">The properties to perform the Levenshtein distance against</param>
+        /// <returns></returns>
+        public IEnumerable<ILevenshteinDistance<T>> ComparedTo(params Expression<Func<T, string>>[] stringProperties)
+        {
+            var targetProperties = stringProperties.Select(AlignParameter).ToArray();
+
+            var levenshteinDistanceExpression = EnumerableExpressionHelper.CalculateLevenshteinDistance(Properties, targetProperties);
+            var buildExpression = EnumerableExpressionHelper.ConstructLevenshteinResult<T>(levenshteinDistanceExpression, FirstParameter);
+            var selectExpression = Expression.Lambda<Func<T, LevenshteinDistance<T>>>(buildExpression, FirstParameter).Compile();
+            var convertedSource = Source.Select(selectExpression.Invoke);
+            return new EnumerableLevenshteinCompare<ILevenshteinDistance<T>>(convertedSource);
+        }
+
+        /// <summary>
+        /// Define the term with which to compare string properties to
+        /// </summary>
+        /// <param name="terms">The terms to perform the Levenshtein distance against</param>
+        /// <returns></returns>
+        public IEnumerable<ILevenshteinDistance<T>> ComparedTo(params string[] terms)
+        {
+            var levenshteinDistanceExpression = EnumerableExpressionHelper.CalculateLevenshteinDistances(Properties, terms);
+
+            var buildExpression = EnumerableExpressionHelper.ConstructLevenshteinResult<T>(levenshteinDistanceExpression, FirstParameter);
+            var selectExpression = Expression.Lambda<Func<T, LevenshteinDistance<T>>>(buildExpression, FirstParameter).Compile();
+            var convertedSource = Source.Select(selectExpression.Invoke);
+            return new EnumerableLevenshteinCompare<ILevenshteinDistance<T>>(convertedSource);
+        }
+
+        public override IEnumerator<T> GetEnumerator()
+        {
+            throw new InvalidOperationException("Please use .ComparedTo() method to provide a value with which to build a Levenshtein Distance.");
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableSearchBase.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableSearchBase.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public abstract class EnumerableSearchBase<TSource, TProperty> : SearchBase<IEnumerable<TSource>, TSource, TProperty>, IEnumerable<TSource>
+    {
+        protected EnumerableSearchBase(IEnumerable<TSource> source, Expression<Func<TSource, TProperty>>[] properties)
+            : base(source, properties)
+        {
+        }
+
+        public virtual IEnumerator<TSource> GetEnumerator()
+        {
+            if (CompleteExpression != null)
+            {
+                var finalExpression = Expression.Lambda<Func<TSource, bool>>(CompleteExpression, FirstParameter).Compile();
+                Source = Source.Where(finalExpression);
+            }
+            return Source.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableSoundexSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableSoundexSearch.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+using NinjaNye.SearchExtensions.Portable.Soundex;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    internal class EnumerableSoundexSearch<T> : EnumerableSearchBase<T, string>
+    {
+        public EnumerableSoundexSearch(IEnumerable<T> source, Expression<Func<T, string>>[] stringProperties) 
+            : base(source, stringProperties)
+        {
+        }
+
+        /// <summary>
+        /// Perform a soundex search for a particular collection of terms 
+        /// based on the American Soundex algorythm 
+        /// as defined on http://en.wikipedia.org/wiki/Soundex
+        /// </summary>
+        /// <param name="terms">Term or terms results should sound similar to</param>
+        /// <returns>Returns only the items that match the soundex codes for the terms supplied</returns>
+        public IEnumerable<T> American(params string[] terms)
+        {
+            Expression fullExpression = null;
+            var soundexCodes = terms.Select(t => t.ToSoundex()).ToList();
+            foreach (var propertyToSearch in Properties)
+            {
+                var soundsLikeExpression = SoundexExpressionBuilder.BuildSoundsLikeExpression(propertyToSearch, soundexCodes);
+                fullExpression = fullExpression == null ? soundsLikeExpression
+                                                        : Expression.OrElse(fullExpression, soundsLikeExpression);
+            }
+            BuildExpression(fullExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Perform a reverse soundex search for a particular collection of terms 
+        /// based on the American Soundex algorythm with the words reversed 
+        /// as defined on http://en.wikipedia.org/wiki/Soundex
+        /// </summary>
+        /// <param name="terms">Term or terms results should sound similar to</param>
+        /// <returns>Returns only the items that match the soundex codes for the terms supplied</returns>
+        public IEnumerable<T> Reverse(params string[] terms)
+        {
+            Expression fullExpression = null;
+            var soundexCodes = terms.Select(t => t.ToReverseSoundex()).ToList();
+            foreach (var propertyToSearch in Properties)
+            {
+                var soundsLikeExpression = SoundexExpressionBuilder.BuildReverseSoundexLikeExpression(propertyToSearch, soundexCodes);
+                fullExpression = fullExpression == null ? soundsLikeExpression
+                                                        : Expression.OrElse(fullExpression, soundsLikeExpression);
+            }
+            BuildExpression(fullExpression);
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableStringSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableStringSearch.cs
@@ -1,0 +1,252 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.ContainsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Models;
+using NinjaNye.SearchExtensions.Portable.Validation;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableStringSearch<T> : EnumerableSearchBase<T, string>
+    {
+        private readonly SearchTermCollection _searchTerms = new SearchTermCollection();
+        private readonly SearchOptions _searchOptions;
+
+        public EnumerableStringSearch(IEnumerable<T> source, Expression<Func<T, string>>[] stringProperties)
+            : base(source, stringProperties)
+        {
+            _searchOptions = new SearchOptions();
+            SetCulture(StringComparison.CurrentCulture);
+        }
+
+        /// <summary>
+        /// Set culture for string comparison
+        /// </summary>
+        public EnumerableStringSearch<T> SetCulture(StringComparison type)
+        {
+            _searchOptions.ComparisonType = type;
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableStringSearch<T> Containing(params string[] terms)
+        {
+            Ensure.ArgumentNotNull(terms, "terms");
+
+            if (!terms.Any() || !Properties.Any())
+            {
+                return this;
+            }
+
+
+            var validSearchTerms = terms.Where(s => !String.IsNullOrWhiteSpace(s)).ToArray();
+            if (!validSearchTerms.Any())
+            {
+                return this;
+            }
+
+            _searchTerms.Add(validSearchTerms);
+            Expression orExpression = EnumerableContainsExpressionBuilder.Build(Properties, validSearchTerms, _searchOptions);
+
+            BuildExpression(orExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Property or properties to search against</param>
+        public EnumerableStringSearch<T> Containing(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            Expression finalExpression = null;
+            foreach (var stringProperty in propertiesToSearchFor)
+            {
+                var containsProperty = AlignParameter(stringProperty);
+                foreach (var propertyToSearch in Properties)
+                {
+                    var containsExpression = EnumerableContainsExpressionBuilder.Build(propertyToSearch, containsProperty);
+                    finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, containsExpression);
+                }
+            }
+
+            BuildExpression(finalExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where all of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableStringSearch<T> ContainingAll(params string[] terms)
+        {
+            for (int i = 0; i < terms.Length; i++)
+            {
+                Containing(terms[i]);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where all of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Properties containg text to search for</param>
+        public EnumerableStringSearch<T> ContainingAll(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            var result = this;
+            foreach (var propertyToSearch in propertiesToSearchFor)
+            {
+                result = result.Containing(propertyToSearch);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties starts 
+        /// with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableStringSearch<T> StartsWith(params string[] terms)
+        {
+            _searchTerms.Add(terms);
+            Expression fullExpression = EnumerableStartsWithExpressionBuilder.Build(Properties, terms, _searchOptions);
+            BuildExpression(fullExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties starts 
+        /// with any of the defined properties
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Term or terms to search for</param>
+        public EnumerableStringSearch<T> StartsWith(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            var propertiesToSearch = propertiesToSearchFor.Select(AlignParameter).ToArray();
+            Expression completeExpression = EnumerableStartsWithExpressionBuilder.Build(Properties, propertiesToSearch, _searchOptions);
+            BuildExpression(completeExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// ends with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableStringSearch<T> EndsWith(params string[] terms)
+        {
+            _searchTerms.Add(terms);
+            Expression fullExpression = EnumerableEndsWithExpressionBuilder.Build(Properties, terms, _searchOptions);
+            BuildExpression(fullExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// ends with any of the defined search terms
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Properties containing terms to search for</param>
+        public EnumerableStringSearch<T> EndsWith(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            var propertiesToSearch = propertiesToSearchFor.Select(AlignParameter).ToArray();
+            Expression finalExpression = EnumerableEndsWithExpressionBuilder.Build(Properties, propertiesToSearch, _searchOptions);
+            BuildExpression(finalExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// are equal to any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public EnumerableStringSearch<T> EqualTo(params string[] terms)
+        {
+            Expression fullExpression = EnumerableEqualsExpressionBuilder.Build(Properties, terms, _searchOptions);
+            BuildExpression(fullExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// are equal to any of the defined properties to search for
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Properties to search for</param>
+        public EnumerableStringSearch<T> EqualTo(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            propertiesToSearchFor = propertiesToSearchFor.Select(AlignParameter).ToArray();
+            Expression completeExpression = EnumerableEqualsExpressionBuilder.Build(Properties, propertiesToSearchFor, _searchOptions);
+            BuildExpression(completeExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Return records that match the Soundex code for any of the given terms
+        /// </summary>
+        /// <param name="terms">terms to search for</param>
+        /// <returns>Enumerable of records where Soundex matches</returns>
+        public IEnumerable<T> Soundex(params string[] terms)
+        {
+            return new EnumerableSoundexSearch<T>(Source, Properties).American(terms);
+        }
+
+        /// <summary>
+        /// Return records that match the Soundex code for any of the given terms
+        /// </summary>
+        /// <param name="terms">terms to search for</param>
+        /// <returns>Enumerable of records where Soundex matches</returns>
+        public IEnumerable<T> ReverseSoundex(params string[] terms)
+        {
+            return new EnumerableSoundexSearch<T>(Source, Properties).Reverse(terms);
+        }
+
+        /// <summary>
+        /// Rank the filtered items based on the matched occurences
+        /// </summary>
+        /// <returns>
+        /// Enumerable of ranked items.  Each item will contain 
+        /// the amount of hits found across the defined properties
+        /// </returns>
+        public IEnumerable<IRanked<T>> ToRanked()
+        {
+            Expression combinedHitExpression = null;
+            foreach (var propertyToSearch in Properties)
+            {
+                for (int j = 0; j < _searchTerms.Count; j++)
+                {
+                    var searchTerm = _searchTerms[j];
+                    var nullSafeExpresion = BuildNullSafeExpresion(propertyToSearch);
+                    var hitCountExpression = EnumerableExpressionHelper.CalculateHitCount(nullSafeExpresion, searchTerm, _searchOptions);
+                    combinedHitExpression = ExpressionHelper.AddExpressions(combinedHitExpression, hitCountExpression);
+                }
+            }
+
+            var rankedInitExpression = EnumerableExpressionHelper.ConstructRankedResult<T>(combinedHitExpression, FirstParameter);
+            var selectExpression = Expression.Lambda<Func<T, Ranked<T>>>(rankedInitExpression, FirstParameter).Compile();
+            return this.Select(selectExpression.Invoke);
+        }
+
+        private Expression<Func<T, string>> BuildNullSafeExpresion(Expression<Func<T, string>> propertyToSearch)
+        {
+            var nullSafeProperty = Expression.Coalesce(propertyToSearch.Body, ExpressionMethods.EmptyStringExpression);
+            var nullSafeExpresion = Expression.Lambda<Func<T, string>>(nullSafeProperty, FirstParameter);
+            return nullSafeExpresion;
+        }
+
+        public EnumerableStringSearch<T> Matching(SearchType searchType)
+        {
+            _searchOptions.SearchType = searchType;
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/EnumerableStructSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/EnumerableStructSearch.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class EnumerableStructSearch<TSource, TProperty> : EnumerableSearchBase<TSource, TProperty> 
+        where TProperty : struct 
+    {
+        public EnumerableStructSearch(IEnumerable<TSource> source, Expression<Func<TSource, TProperty>>[] properties) 
+            : base(source, properties)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// equal any of the supplied values
+        /// </summary>
+        /// <param name="values">Values to search for</param>
+        public EnumerableStructSearch<TSource, TProperty> EqualTo(params TProperty[] values)
+        {
+            var equalsExpression = ExpressionBuilder.EqualsExpression(Properties, values);
+            BuildExpression(equalsExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableStructSearch<TSource, TProperty> GreaterThan(TProperty value)
+        {
+            var greaterThanExpression = ExpressionBuilder.GreaterThanExpression(Properties, value);
+            BuildExpression(greaterThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are less than any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableStructSearch<TSource, TProperty> LessThan(TProperty value)
+        {
+            var greaterThanExpression = ExpressionBuilder.LessThanExpression(Properties, value);
+            BuildExpression(greaterThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are less than or equal to any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableStructSearch<TSource, TProperty> LessThanOrEqualTo(TProperty value)
+        {
+            var lessThanOrEqualExpression = ExpressionBuilder.LessThanOrEqualExpression(Properties, value);
+            BuildExpression(lessThanOrEqualExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than or equal to any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public EnumerableStructSearch<TSource, TProperty> GreaterThanOrEqualTo(TProperty value)
+        {
+            var greaterThanOrEqualExpression = ExpressionBuilder.GreaterThanOrEqualExpression(Properties, value);
+            BuildExpression(greaterThanOrEqualExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than <paramref name="minValue">minValue</paramref> 
+        /// AND less than <paramref name="maxValue">maxValue</paramref> 
+        /// </summary>
+        public EnumerableStructSearch<TSource, TProperty> Between(TProperty minValue, TProperty maxValue)
+        {
+            var betweenExpression = ExpressionBuilder.BetweenExpression(Properties, minValue, maxValue);
+            BuildExpression(betweenExpression);
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/FluentChildSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/FluentChildSearch.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public static class FluentChildSearch
+    {
+        /// <summary>
+        /// Identify a child collection to search on
+        /// </summary>
+        /// <remarks>
+        /// Initially wanted to have this method named `Search` as an 
+        /// overload to the normal search methods, however due to the constraints
+        /// of the .Net method resolution...
+        /// (http://stackoverflow.com/questions/33231636/making-use-of-polymorphism-in-a-generic-parameter)
+        /// this was not possible.
+        /// </remarks>
+        /// <typeparam name="TSource">Type of object to be searched</typeparam>
+        /// <typeparam name="TProperty">Type of property to be searched</typeparam>
+        /// <param name="source">source data on which to search</param>
+        /// <param name="properties">Enumerable properties to search.</param>
+        public static EnumerableChildSelector<TSource, TProperty> SearchChildren<TSource, TProperty>(this IEnumerable<TSource> source, params Expression<Func<TSource, IEnumerable<TProperty>>>[] properties)
+        {
+            return new EnumerableChildSelector<TSource, TProperty>(source, properties);
+        }
+
+        /// <summary>
+        /// Identify a child collection to search on
+        /// </summary>
+        /// <typeparam name="TSource">Type of object to be searched</typeparam>
+        /// <typeparam name="TProperty">Type of property to be searched</typeparam>
+        /// <param name="source">source data on which to search</param>
+        /// <param name="properties">Enumerable properties to search.</param>
+        public static QueryableChildSelector<TSource, TProperty> SearchChildren<TSource, TProperty>(this IQueryable<TSource> source, params Expression<Func<TSource, IEnumerable<TProperty>>>[] properties)
+        {
+            return new QueryableChildSelector<TSource, TProperty>(source, properties);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/FluentLevenshteinSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/FluentLevenshteinSearch.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Validation;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public static class FluentLevenshteinSearch
+    {
+        /// <summary>
+        /// Begin a Levenshtein comparison on Enumerable collection of objects
+        /// </summary>
+        /// <typeparam name="T">Type of object to be searched</typeparam>
+        /// <param name="source">source data on which to perform search</param>
+        /// <param name="stringProperties">String property to search.</param>
+        public static EnumerableLevenshteinSearch<T> LevenshteinDistanceOf<T>(this IEnumerable<T> source, params Expression<Func<T, string>>[] stringProperties)
+        {
+            Ensure.ArgumentNotNull(stringProperties, "stringProperties");
+            return new EnumerableLevenshteinSearch<T>(source, stringProperties);
+        }        
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/FluentSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/FluentSearch.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public static class FluentSearch
+    {
+        /// <summary>
+        /// Search an Enumerable list of objects
+        /// </summary>
+        /// <typeparam name="TSource">Type of object to be searched</typeparam>
+        /// <typeparam name="TProperty">Type of property to be searched</typeparam>
+        /// <param name="source">source data on which to perform search</param>
+        /// <param name="properties">
+        /// Properties to search.</param>
+        public static EnumerableStructSearch<TSource, TProperty> Search<TSource, TProperty>(this IEnumerable<TSource> source, params Expression<Func<TSource, TProperty>>[] properties) 
+            where TProperty : struct
+        {
+            return new EnumerableStructSearch<TSource, TProperty>(source, properties);
+        }
+
+        /// <summary>
+        /// Search a Queryable list of objects
+        /// </summary>
+        /// <typeparam name="TSource">Type of object to be searched</typeparam>
+        /// <typeparam name="TProperty">Type of property to be searched</typeparam>
+        /// <param name="source">source data on which to perform search</param>
+        /// <param name="properties">Properties to search.</param>
+        public static QueryableStructSearch<TSource, TProperty> Search<TSource, TProperty>(this IQueryable<TSource> source, params Expression<Func<TSource, TProperty>>[] properties) 
+            where TProperty : struct
+        {
+            return new QueryableStructSearch<TSource, TProperty>(source, properties);
+        }        
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/FluentStringSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/FluentStringSearch.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public static class FluentStringSearch
+    {
+        /// <summary>
+        /// Search an Enumerable list of objects
+        /// </summary>
+        /// <typeparam name="T">Type of object to be searched</typeparam>
+        public static EnumerableStringSearch<T> Search<T>(this IEnumerable<T> source)
+        {
+            var stringProperties = EnumerableExpressionHelper.GetProperties<T, string>();
+            return new EnumerableStringSearch<T>(source, stringProperties);
+        }
+
+        /// <summary>
+        /// Search an Enumerable list of objects
+        /// </summary>
+        /// <typeparam name="T">Type of object to be searched</typeparam>
+        /// <param name="source"></param>
+        /// <param name="stringProperties">
+        /// String properties to search. If ommitted, a search 
+        /// on all string properties will be performed
+        /// </param>
+        public static EnumerableStringSearch<T> Search<T>(this IEnumerable<T> source, params Expression<Func<T, string>>[] stringProperties)
+        {
+            if (stringProperties == null || stringProperties.All(sp => sp == null))
+            {
+                stringProperties = EnumerableExpressionHelper.GetProperties<T, string>();
+            }
+
+            return new EnumerableStringSearch<T>(source, stringProperties);
+        }
+
+        /// <summary>
+        /// Search a Queryable collection
+        /// </summary>
+        /// <typeparam name="T">Type of object to be searched</typeparam>
+        public static QueryableStringSearch<T> Search<T>(this IQueryable<T> source)
+        {
+            var properties = EnumerableExpressionHelper.GetProperties<T, string>();
+            return new QueryableStringSearch<T>(source, properties);
+        }
+
+        /// <summary>
+        /// Search a Queryable collection
+        /// </summary>
+        /// <typeparam name="T">Type of object to be searched</typeparam>
+        /// <param name="source"></param>
+        /// <param name="stringProperties">
+        /// String properties to search. If ommitted, a search 
+        /// on all string properties will be performed
+        /// </param>
+        public static QueryableStringSearch<T> Search<T>(this IQueryable<T> source, params Expression<Func<T, string>>[] stringProperties)
+        {
+            if (stringProperties == null || stringProperties.All(sp => sp == null))
+            {
+                stringProperties = EnumerableExpressionHelper.GetProperties<T, string>();
+            }
+
+            return new QueryableStringSearch<T>(source, stringProperties);
+        }
+
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ContainsExpressionBuilder/EnumerableContainsExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ContainsExpressionBuilder/EnumerableContainsExpressionBuilder.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.ContainsExpressionBuilder
+{
+    public static class EnumerableContainsExpressionBuilder
+    {
+        /// <summary>
+        /// Build a 'contains' expression for a searching a property that 
+        /// contains the value of another string property
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>> propertyToSearch, Expression<Func<T, string>> propertyToSearchFor)
+        {
+            var isNotNullExpression = ExpressionHelper.BuildNotNullExpression(propertyToSearch);
+            var searchForIsNotNullExpression = ExpressionHelper.BuildNotNullExpression(propertyToSearchFor);
+            var containsExpression = Expression.Call(propertyToSearch.Body, ExpressionMethods.StringContainsMethod, propertyToSearchFor.Body);
+            var fullNotNullExpression = Expression.AndAlso(isNotNullExpression, searchForIsNotNullExpression);
+            return Expression.AndAlso(fullNotNullExpression, containsExpression);
+        }
+
+        /// <summary>
+        /// Build a 'indexof() >= 0' expression for a search term against a particular string property
+        /// </summary>
+        private static BinaryExpression Build<T>(Expression<Func<T, string>> propertyToSearch, ConstantExpression searchTermExpression, ConstantExpression stringComparisonExpression)
+        {
+            var coalesceExpression = Expression.Coalesce(propertyToSearch.Body, ExpressionMethods.EmptyStringExpression);
+            var nullCheckExpresion = Expression.Call(coalesceExpression, ExpressionMethods.IndexOfMethodWithComparison, searchTermExpression, stringComparisonExpression);
+            return Expression.GreaterThanOrEqual(nullCheckExpresion, ExpressionMethods.ZeroConstantExpression);
+        }
+
+        private static Expression Build<T>(Expression<Func<T, string>> propertyToSearch, IEnumerable<string> searchTerms, ConstantExpression stringComparisonExpression, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            bool isWholeWordSearch = searchType == SearchType.WholeWords;
+            foreach (var searchTerm in searchTerms)
+            {
+                var searchTermExpression = Expression.Constant(isWholeWordSearch ? " " + searchTerm + " " : searchTerm);
+                var containsExpression = Build(propertyToSearch, searchTermExpression, stringComparisonExpression);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, containsExpression);
+            }
+
+            return completeExpression;
+        }
+
+        public static Expression Build<T>(Expression<Func<T, string>>[] properties, string[] searchTerms, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            var comparisonTypeExpression = Expression.Constant(searchOptions.ComparisonType);
+            foreach (var stringProperty in properties)
+            {
+                var containsExpression = Build(stringProperty, searchTerms, comparisonTypeExpression, searchOptions.SearchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, containsExpression);
+            }
+
+            if (searchOptions.SearchType == SearchType.WholeWords)
+            {
+                var startsWithExpression = EnumerableStartsWithExpressionBuilder.Build(properties, searchTerms, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+
+                var endsWithExpression = EnumerableEndsWithExpressionBuilder.Build(properties, searchTerms, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, endsWithExpression);
+
+                var equalsExpression = EnumerableEqualsExpressionBuilder.Build(properties, searchTerms, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, equalsExpression);
+            }
+            return completeExpression;
+        }
+
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ContainsExpressionBuilder/QueryableContainsExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ContainsExpressionBuilder/QueryableContainsExpressionBuilder.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Validation;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.ContainsExpressionBuilder
+{
+    internal static class QueryableContainsExpressionBuilder
+    {
+        public static Expression Build<T>(Expression<Func<T, string>>[] propertiesToSearch, ICollection<string> searchTerms, SearchType searchType)
+        {
+            Expression result = null;
+            foreach (var propertyToSearch in propertiesToSearch)
+            {
+                var containsExpression = Build(propertyToSearch, searchTerms, searchType);
+                result = ExpressionHelper.JoinOrExpression(result, containsExpression);
+            }
+
+            if (searchType == SearchType.WholeWords)
+            {
+                var terms = searchTerms.ToArray();
+                var startsWithExpression = QueryableStartsWithExpressionBuilder.Build(propertiesToSearch, terms, searchType);
+                result = ExpressionHelper.JoinOrExpression(result, startsWithExpression);
+                var endsWithExpression = QueryableEndsWithExpressionBuilder.Build(propertiesToSearch, terms, searchType);
+                result = ExpressionHelper.JoinOrExpression(result, endsWithExpression);
+
+                var equalsExpression = QueryableEqualsExpressionBuilder.Build(propertiesToSearch, terms);
+                result = ExpressionHelper.JoinOrExpression(result, equalsExpression);
+            }
+
+            return result;
+        }
+
+        private static Expression Build<T>(Expression<Func<T, string>> propertyToSearch, ICollection<string> searchTerms, SearchType searchType)
+        {
+            Expression result = null;
+            foreach (var searchTerm in searchTerms)
+            {
+                Expression comparisonExpression = Build(propertyToSearch, searchTerm, searchType);
+                result = ExpressionHelper.JoinOrExpression(result, comparisonExpression);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Build a 'contains' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> propertyToSearch, string searchTerm, SearchType searchType)
+        {
+            Ensure.ArgumentNotNull(searchTerm, "searchTerm");
+            if (searchType == SearchType.WholeWords)
+            {
+                searchTerm = " " + searchTerm + " ";
+            }
+            ConstantExpression searchTermExpression = Expression.Constant(searchTerm);
+            return Expression.Call(propertyToSearch.Body, ExpressionMethods.StringContainsMethod, searchTermExpression);
+        }
+
+        /// <summary>
+        /// Build a 'contains' expression to search a string property contained within another string property
+        /// </summary>
+        /// <param name="propertyToSearch">Property on which to perform search</param>
+        /// <param name="propertyToSearchFor">Property containing the value to search for</param>
+        /// <returns></returns>
+        public static Expression Build<T>(Expression<Func<T, string>> propertyToSearch, Expression<Func<T, string>> propertyToSearchFor)
+        {
+            return Expression.Call(propertyToSearch.Body, ExpressionMethods.StringContainsMethod, propertyToSearchFor.Body);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EndsWithExpressionBuilder/EnumerableEndsWithExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EndsWithExpressionBuilder/EnumerableEndsWithExpressionBuilder.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder
+{
+    internal static class EnumerableEndsWithExpressionBuilder
+    {
+        /// <summary>
+        /// Build an 'EndsWith' expression for a collection of search terms against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, IEnumerable<string> searchTerms, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var searchTerm in searchTerms)
+            {
+                var endsWithExpression = Build(stringProperty, searchTerm, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, endsWithExpression);
+            }
+
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, string searchTerm, SearchOptions searchOptions)
+        {
+            var alteredTerm = searchOptions.SearchType == SearchType.WholeWords ? " " + searchTerm : searchTerm;
+            var searchTermExpression = Expression.Constant(alteredTerm);
+            var endsWithExpresion = Expression.Call(stringProperty.Body, ExpressionMethods.EndsWithMethodWithComparison, searchTermExpression, searchOptions.ComparisonTypeExpression);
+            return Expression.IsTrue(endsWithExpresion);
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression for a collection of properties against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>>[] propertiesToSearchFor, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearchFor in propertiesToSearchFor)
+            {
+                var endsWithExpression = Build(stringProperty, propertyToSearchFor, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, endsWithExpression);
+            }
+
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression for a string property against a property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>> propertyToSearchFor, SearchOptions searchOptions)
+        {
+            var endsWithExpresion = Expression.Call(stringProperty.Body, ExpressionMethods.EndsWithMethodWithComparison, propertyToSearchFor.Body, searchOptions.ComparisonTypeExpression);
+            Expression finalExpression = null;
+            if (searchOptions.NullCheck)
+            {
+                var notNullProperty = ExpressionHelper.BuildNotNullExpression(stringProperty);
+                var notNullSearchFor = ExpressionHelper.BuildNotNullExpression(propertyToSearchFor);
+                finalExpression = ExpressionHelper.JoinAndAlsoExpression(notNullProperty, notNullSearchFor);
+            }
+            finalExpression = ExpressionHelper.JoinAndAlsoExpression(finalExpression, endsWithExpresion);
+            return Expression.IsTrue(finalExpression);
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression comparing multiple string properties against other string properties
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, Expression<Func<T, string>>[] propertiesToSearchFor, SearchOptions searchOptions)
+        {
+            Expression finalExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var endsWithExpression = Build(stringProperty, propertiesToSearchFor, searchOptions);
+                finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, endsWithExpression);
+            }
+            return finalExpression;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith([searchTerm])' expression comparing multiple string properties against string terms
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, string[] searchTerms, SearchOptions searchOptions)
+        {
+            Expression finalExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var endsWithExpression = Build(stringProperty, searchTerms, searchOptions);
+                finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, endsWithExpression);
+            }
+            return finalExpression;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EndsWithExpressionBuilder/QueryableEndsWithExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EndsWithExpressionBuilder/QueryableEndsWithExpressionBuilder.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder
+{
+    internal static class QueryableEndsWithExpressionBuilder
+    {
+        /// <summary>
+        /// Build an 'EndsWith' expression for a collection of search terms against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, IEnumerable<string> searchTerms, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            foreach (var searchTerm in searchTerms)
+            {
+                var endsWithExpression = Build(stringProperty, searchTerm, searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, endsWithExpression);
+            }
+
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, string searchTerm, SearchType searchType)
+        {
+            var alteredSearchTerm = searchType == SearchType.WholeWords ? " " + searchTerm : searchTerm;
+            var searchTermExpression = Expression.Constant(alteredSearchTerm);
+            return Expression.Call(stringProperty.Body, ExpressionMethods.EndsWithMethod, searchTermExpression);
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression for a collection of properties against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>>[] propertiesToSearchFor, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearchFor in propertiesToSearchFor)
+            {
+                var endsWithExpression = Build(stringProperty, propertyToSearchFor, searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, endsWithExpression);
+            }
+
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression for a string property against multiple properties
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>> propertyToSearchFor, SearchType searchType)
+        {
+            var paddedTerm = propertyToSearchFor.Body;
+            if (searchType == SearchType.WholeWords)
+            {
+                var seperator = Expression.Constant(" ");
+                paddedTerm = Expression.Call(ExpressionMethods.StringConcatMethod, seperator, propertyToSearchFor.Body);
+            }
+
+            var result = Expression.Call(stringProperty.Body, ExpressionMethods.EndsWithMethod, paddedTerm);
+            if (searchType == SearchType.WholeWords)
+            {
+                var isEqualExpression = QueryableEqualsExpressionBuilder.Build(stringProperty, propertyToSearchFor);
+                return ExpressionHelper.JoinOrExpression(result, isEqualExpression);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith' expression comparing multiple string properties against other string properties
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, Expression<Func<T, string>>[] propertiesToSearchFor, SearchType searchType)
+        {
+            Expression finalExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var endsWithExpression = Build(stringProperty, propertiesToSearchFor, searchType);
+                finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, endsWithExpression);
+            }
+            return finalExpression;
+        }
+
+        /// <summary>
+        /// Build an 'EndsWith([searchTerm])' expression comparing multiple string properties against string terms
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, string[] searchTerms, SearchType searchType)
+        {
+            Expression finalExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var endsWithExpression = Build(stringProperty, searchTerms, searchType);
+                finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, endsWithExpression);
+            }
+            return finalExpression;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EnumerableExpressionHelper.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using NinjaNye.SearchExtensions.Portable.Levenshtein;
+using NinjaNye.SearchExtensions.Portable.Models;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders
+{
+    internal static class EnumerableExpressionHelper
+    {
+        /// <summary>
+        /// Constructs a ranked result of type T
+        /// </summary>
+        /// <param name="hitCountExpression">Expression representing how to calculated search hits</param>
+        /// <param name="parameterExpression">property parameter</param>
+        /// <returns>Expression equivalent to: new Ranked{ Hits = [hitCountExpression], Item = x }</returns>
+        public static Expression ConstructRankedResult<T>(Expression hitCountExpression,
+                                                          ParameterExpression parameterExpression)
+        {
+            var rankedType = typeof(Ranked<T>);
+            var rankedCtor = Expression.New(rankedType);
+            PropertyInfo hitProperty = rankedType.GetRuntimeProperty("Hits");
+            PropertyInfo itemProperty = rankedType.GetRuntimeProperty("Item");
+            var hitValueAssignment = Expression.Bind(hitProperty, hitCountExpression);
+            var itemValueAssignment = Expression.Bind(itemProperty, parameterExpression);
+            return Expression.MemberInit(rankedCtor, hitValueAssignment, itemValueAssignment);
+        }
+
+        /// <summary>
+        /// Constructs a ranked result of type T
+        /// </summary>
+        /// <param name="distanceExpressions">Expression representing how to calculated distance</param>
+        /// <param name="parameterExpression">property parameter</param>
+        /// <returns>Expression equivalent to: new LevenshteinDistance{ Distance = [hitCountExpression], Item = x }</returns>
+        public static Expression ConstructLevenshteinResult<T>(IEnumerable<Expression> distanceExpressions,
+                                                               ParameterExpression parameterExpression)
+        {
+            var distanceType = typeof(LevenshteinDistance<T>);
+            Func<ConstructorInfo, bool> predicate = c =>
+            {
+                var parameters = c.GetParameters();
+                if (parameters != null && parameters.Length == 2)
+                {
+                    return parameters[0].ParameterType == typeof(T) && parameters[1].ParameterType == typeof(int[]);
+                }
+                return false;
+            };
+            var constructor = distanceType.GetTypeInfo().DeclaredConstructors.FirstOrDefault(predicate);
+            var distanceArray = Expression.NewArrayInit(typeof(int), distanceExpressions);
+            var distanceCtor = Expression.New(constructor, parameterExpression, distanceArray);
+            return distanceCtor;
+        }
+
+        /// <summary>
+        /// Calculates how many search hits occured for a given property
+        /// </summary>
+        /// <param name="stringProperty">string property to analyse</param>
+        /// <param name="searchTerm">search term to count</param>
+        /// <returns>Expression equivalent to: [property].Length - ([property].Replace([searchTerm], "").Length) / [searchTerm].Length</returns>
+        public static Expression CalculateHitCount<T>(Expression<Func<T, string>> stringProperty, string searchTerm)
+        {
+            Expression searchTermExpression = Expression.Constant(searchTerm);
+            Expression searchTermLengthExpression = Expression.Constant(searchTerm.Length);
+            MemberExpression lengthExpression = Expression.Property(stringProperty.Body, ExpressionMethods.StringLengthProperty);
+            var replaceExpression = Expression.Call(stringProperty.Body, ExpressionMethods.ReplaceMethod,
+                                                    searchTermExpression, ExpressionMethods.EmptyStringExpression);
+            var replacedLengthExpression = Expression.Property(replaceExpression, ExpressionMethods.StringLengthProperty);
+            var characterDiffExpression = Expression.Subtract(lengthExpression, replacedLengthExpression);
+            var hitCountExpression = Expression.Divide(characterDiffExpression, searchTermLengthExpression);
+            return hitCountExpression;
+        }
+
+        /// <summary>
+        /// Calculates how many search hits occured for a given property
+        /// </summary>
+        /// <returns>Expression equivalent to: [property].Length - ([property].Replace([searchTerm], "").Length) / [searchTerm].Length</returns>
+        public static Expression CalculateHitCount<T>(Expression<Func<T, string>> stringProperty, string searchTerm, SearchOptions searchOptions)
+        {
+            Expression searchTermExpression = Expression.Constant(searchTerm);
+            Expression searchTermLengthExpression = Expression.Constant(searchTerm.Length);
+            MemberExpression lengthExpression = Expression.Property(stringProperty.Body, ExpressionMethods.StringLengthProperty);
+            var replaceExpression = Expression.Call(ExpressionMethods.CustomReplaceMethod, stringProperty.Body, searchTermExpression, ExpressionMethods.EmptyStringExpression, searchOptions.ComparisonTypeExpression);
+            var replacedLengthExpression = Expression.Property(replaceExpression, ExpressionMethods.StringLengthProperty);
+            var characterDiffExpression = Expression.Subtract(lengthExpression, replacedLengthExpression);
+            var hitCountExpression = Expression.Divide(characterDiffExpression, searchTermLengthExpression);
+            return hitCountExpression;
+        }
+
+        /// <summary>
+        /// Calculates the Levenshtein distance between a given property and a search term
+        /// </summary>
+        /// <returns>Expression equivalent to: LevenshteinProcessor.LevensteinDistance([stringProperty], [searchTerm])</returns>
+        public static IEnumerable<Expression> CalculateLevenshteinDistances<T>(Expression<Func<T, string>>[] stringProperties, params string[] searchTerms)
+        {
+            var searchTermExpressions = searchTerms.Select(Expression.Constant).ToList();
+            return from searchTerm in searchTermExpressions
+                   from sourceProperty in stringProperties
+                   select Expression.Call(ExpressionMethods.LevensteinDistanceMethod, sourceProperty.Body, searchTerm);
+        }
+
+        /// <summary>
+        /// Calculates the Levenshtein distance between a given property and a search term
+        /// </summary>
+        /// <returns>Expression equivalent to: LevenshteinProcessor.LevensteinDistance([stringProperty], [searchTerm])</returns>
+        public static IEnumerable<Expression> CalculateLevenshteinDistance<T>(
+            Expression<Func<T, string>>[] sourceProperties, params Expression<Func<T, string>>[] targetProperties)
+        {
+            return from targetProperty in targetProperties
+                   from sourceProperty in sourceProperties
+                   select Expression.Call(ExpressionMethods.LevensteinDistanceMethod, sourceProperty.Body, targetProperty.Body);
+        }
+
+
+        /// <summary>
+        /// Builds an array of expressions that map to every TType property on an object
+        /// </summary>
+        /// <typeparam name="TSource">Type of object to retrieve properties from</typeparam>
+        /// <typeparam name="TType">The type of property to locate</typeparam>
+        /// <returns>An array of expressions pointing to each TType property</returns>
+        public static Expression<Func<TSource, TType>>[] GetProperties<TSource, TType>()
+        {
+            var parameter = Expression.Parameter(typeof(TSource));
+            var stringProperties = typeof(TSource).GetRuntimeProperties()
+                                                  .Where(property => property.CanRead
+                                                                  && property.PropertyType == typeof(TType));
+
+            var result = new List<Expression<Func<TSource, TType>>>();
+            foreach (var property in stringProperties)
+            {
+                Expression body = Expression.Property(parameter, property);
+                result.Add(Expression.Lambda<Func<TSource, TType>>(body, parameter));
+            }
+            return result.ToArray();
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EqualsExpressionBuilder/EnumerableEqualsExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EqualsExpressionBuilder/EnumerableEqualsExpressionBuilder.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder
+{
+    internal static class EnumerableEqualsExpressionBuilder
+    {
+        /// <summary>
+        /// Build an 'equals' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<TSource, TType>(Expression<Func<TSource, TType>>[] properties, string[] terms, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearch in properties)
+            {
+                var isEqualExpression = Build(propertyToSearch, terms, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, isEqualExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'equals' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<TSource, TType>(Expression<Func<TSource, TType>> property, IEnumerable<string> terms, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var term in terms)
+            {
+                var searchTermExpression = Expression.Constant(term);
+                var equalsExpression = Expression.Call(property.Body, ExpressionMethods.EqualsMethod, searchTermExpression, searchOptions.ComparisonTypeExpression);
+                completeExpression = completeExpression == null ? equalsExpression
+                    : ExpressionHelper.JoinOrExpression(completeExpression, equalsExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'equals' expression for one string property against another string property
+        /// </summary>
+        public static Expression Build<TSource, TType>(Expression<Func<TSource, TType>>[] propertiesToSearch, Expression<Func<TSource, TType>>[] propertiesToSearchFor, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearch in propertiesToSearch)
+            {
+                var isEqualExpression = Build(propertyToSearch, propertiesToSearchFor, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, isEqualExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'equals' expression for one string property against another string property
+        /// </summary>
+        private static Expression Build<TSource, TType>(Expression<Func<TSource, TType>> propertyToSearch, IEnumerable<Expression<Func<TSource, TType>>> propertiesToSearchFor, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearchFor in propertiesToSearchFor)
+            {
+                var isEqualExpression = Expression.Call(propertyToSearch.Body, ExpressionMethods.EqualsMethod, propertyToSearchFor.Body, searchOptions.ComparisonTypeExpression);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, isEqualExpression);
+            }
+            return completeExpression;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EqualsExpressionBuilder/ExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EqualsExpressionBuilder/ExpressionBuilder.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder
+{
+    internal static class ExpressionBuilder
+    {
+        /// <summary>
+        /// Build an 'equals' expression for a value against supplied properties
+        /// </summary>
+        public static Expression EqualsExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType[] values)
+        {
+            Expression completeExpression = null;
+            foreach (var value in values)
+            {
+                var equalExpression = DynamicExpression(properties, value, Expression.Equal);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, equalExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build a 'greater than' expression for a value against supplied properties
+        /// </summary>
+        public static Expression GreaterThanExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType value)
+        {
+            return DynamicExpression(properties, value, Expression.GreaterThan);
+        }
+
+        /// <summary>
+        /// Build a 'less than' expression for a value against supplied properties
+        /// </summary>
+        public static Expression LessThanExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType value)
+        {
+            return DynamicExpression(properties, value, Expression.LessThan);
+        }
+
+        /// <summary>
+        /// Build a 'less than or equal' expression for a value against supplied properties
+        /// </summary>
+        public static Expression LessThanOrEqualExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType value)
+        {
+            return DynamicExpression(properties, value, Expression.LessThanOrEqual);
+        }
+
+        /// <summary>
+        /// Build a 'greater than or equal' expression for a value against supplied properties
+        /// </summary>
+        public static Expression GreaterThanOrEqualExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType value)
+        {
+            return DynamicExpression(properties, value, Expression.GreaterThanOrEqual);
+        }
+
+        public static Expression BetweenExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType minValue, TType maxValue)
+        {
+            Expression completeExpression = null;
+            var minValueExpression = Expression.Constant(minValue);
+            var maxValueExpression = Expression.Constant(maxValue);
+            foreach (var property in properties)
+            {
+                var greaterThanExpression = Expression.GreaterThan(property.Body, minValueExpression);
+                var lessThanExpression = Expression.LessThan(property.Body, maxValueExpression);
+                var betweenExpression = Expression.AndAlso(greaterThanExpression, lessThanExpression);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, betweenExpression);
+            }
+            return completeExpression;
+        }
+
+        private static Expression DynamicExpression<TSource, TType>(Expression<Func<TSource, TType>>[] properties, TType value, Func<Expression, ConstantExpression, Expression> buildComparisonExpression)
+        {
+            Expression completeExpression = null;
+            var valueExpression = Expression.Constant(value);
+            foreach (var property in properties)
+            {
+                var expression = buildComparisonExpression(property.Body, valueExpression);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, expression);
+            }
+            return completeExpression;
+        }
+        
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EqualsExpressionBuilder/QueryableEqualsExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/EqualsExpressionBuilder/QueryableEqualsExpressionBuilder.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder
+{
+    internal static class QueryableEqualsExpressionBuilder
+    {
+        /// <summary>
+        /// Build an 'equals' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<TSource, TType>(Expression<Func<TSource, TType>>[] properties, string[] terms)
+        {
+            Expression completeExpression = null;
+            foreach (var property in properties)
+            {
+                var equalsExpression = Build(property, terms);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, equalsExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'equals' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<TSource, TType>(Expression<Func<TSource, TType>> property, IEnumerable<string> terms)
+        {
+            Expression completeExpression = null;
+            foreach (var term in terms)
+            {
+                var searchTermExpression = Expression.Constant(term);
+                var equalsExpression = Expression.Equal(property.Body, searchTermExpression);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, equalsExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'equals' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<TSource, TType>(Expression<Func<TSource, TType>> source,
+                                                       IEnumerable<Expression<Func<TSource, TType>>> comparedTo)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearchFor in comparedTo)
+            {
+                var isEqualExpression = Build(source, propertyToSearchFor);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, isEqualExpression);
+            }
+
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'equals' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<TSource, TType>(Expression<Func<TSource, TType>> source,
+                                                       Expression<Func<TSource, TType>> comparedTo)
+        {
+            return Expression.Equal(source.Body, comparedTo.Body);
+        }             
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ExpressionHelper.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ExpressionHelper.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders
+{
+    internal static class ExpressionHelper
+    {
+        /// <summary>
+        /// Join two expressions using the add operation
+        /// </summary>
+        /// <param name="existingExpression">Expression being summed</param>
+        /// <param name="expressionToAdd">Expression to append</param>
+        /// <returns>New expression containing both expressions joined using the Add operation</returns>
+        public static Expression AddExpressions(Expression existingExpression, Expression expressionToAdd)
+        {
+            if (existingExpression == null)
+            {
+                return expressionToAdd;
+            }
+
+            return Expression.Add(existingExpression, expressionToAdd);
+        }
+
+        /// <summary>
+        /// Join two expressions using the conditional OR operation
+        /// </summary>
+        /// <param name="existingExpression">Expression being joined</param>
+        /// <param name="expressionToJoin">Expression to append</param>
+        /// <returns>New expression containing both expressions joined using the conditional OR operation</returns>
+        public static Expression JoinOrExpression(Expression existingExpression, Expression expressionToJoin)
+        {
+            if (existingExpression == null)
+            {
+                return expressionToJoin;
+            }
+
+            return Expression.OrElse(existingExpression, expressionToJoin);
+        }
+
+        /// <summary>
+        /// Join two expressions using the conditional AND operation
+        /// </summary>
+        /// <param name="existingExpression">Expression being joined</param>
+        /// <param name="expressionToJoin">Expression to append</param>
+        /// <returns>New expression containing both expressions joined using the conditional OR operation</returns>
+        public static Expression JoinAndAlsoExpression(Expression existingExpression, Expression expressionToJoin)
+        {
+            if (existingExpression == null)
+            {
+                return expressionToJoin;
+            }
+
+            return Expression.AndAlso(existingExpression, expressionToJoin);
+        }
+
+        /// <summary>
+        /// Build a 'not null' expression for a particular string property
+        /// </summary>
+        public static Expression BuildNotNullExpression<T, TType>(Expression<Func<T, TType>> property)
+        {
+            return Expression.NotEqual(property.Body, ExpressionMethods.NullExpression);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ExpressionMethods.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/ExpressionMethods.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using NinjaNye.SearchExtensions.Portable.Levenshtein;
+using NinjaNye.SearchExtensions.Portable.Soundex;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders
+{
+    public static class ExpressionMethods
+    {
+        #region Constants
+        public static readonly ConstantExpression EmptyStringExpression = Expression.Constant(string.Empty);
+        public static readonly ConstantExpression NullExpression = Expression.Constant(null);
+        public static readonly ConstantExpression ZeroConstantExpression = Expression.Constant(0);
+        public static readonly Type stringType = typeof(string);
+        #endregion
+
+        #region Properties
+        public static readonly PropertyInfo StringLengthProperty = stringType.GetRuntimeProperty("Length");
+        #endregion
+
+        #region Methods
+
+        public static readonly MethodInfo IndexOfMethod = typeof (string).GetRuntimeMethod("IndexOf", new[] { stringType });
+        public static readonly MethodInfo IndexOfMethodWithComparison = stringType.GetRuntimeMethod("IndexOf", new[] { stringType, typeof(StringComparison) });
+        public static readonly MethodInfo ReplaceMethod = stringType.GetRuntimeMethod("Replace", new[] { stringType, stringType });
+        public static readonly MethodInfo EqualsMethod = stringType.GetRuntimeMethod("Equals", new[] { stringType, typeof(StringComparison) });
+        public static readonly MethodInfo StartsWithMethod = stringType.GetRuntimeMethod("StartsWith", new[] { stringType });
+        public static readonly MethodInfo StartsWithMethodWithComparison = stringType.GetRuntimeMethod("StartsWith", new[] { stringType, typeof(StringComparison) });
+        public static readonly MethodInfo EndsWithMethod = stringType.GetRuntimeMethod("EndsWith", new[] { stringType });
+        public static readonly MethodInfo EndsWithMethodWithComparison = stringType.GetRuntimeMethod("EndsWith", new[] { stringType, typeof(StringComparison) });
+        public static readonly MethodInfo StringConcatMethod = stringType.GetRuntimeMethod("Concat", new[] { stringType, stringType });
+        public static readonly MethodInfo StringContainsMethod = stringType.GetRuntimeMethod("Contains", new[] { stringType });
+        public static readonly MethodInfo StringListContainsMethod = typeof(List<string>).GetRuntimeMethod("Contains", new[] { stringType });
+        public static readonly MethodInfo SoundexMethod = typeof(SoundexProcessor).GetRuntimeMethod("ToSoundex", new [] { stringType });
+        public static readonly MethodInfo ReverseSoundexMethod = typeof(SoundexProcessor).GetRuntimeMethod("ToReverseSoundex", new [] { stringType });
+        public static readonly MethodInfo LevensteinDistanceMethod = typeof(LevenshteinProcessor).GetRuntimeMethod("LevenshteinDistance", new [] { stringType, stringType });
+        public static readonly MethodInfo CustomReplaceMethod = typeof(StringExtensionHelper).GetRuntimeMethod("Replace", new[] { stringType, stringType, stringType, typeof(StringComparison) });
+        public static readonly MethodInfo QuickReverseMethod = typeof(StringExtensionHelper).GetRuntimeMethod("QuickReverse", new [] { stringType });
+
+        public static readonly MethodInfo AnyQueryableMethod = typeof(Enumerable).GetRuntimeMethods()
+                                                                                 .Single(mi => mi.Name == "Any" 
+                                                                                            && mi.GetParameters().Length == 2);
+
+        #endregion
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/SoundexExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/SoundexExpressionBuilder.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders
+{
+    internal static class SoundexExpressionBuilder
+    {
+        /// <summary>
+        /// Build an 'soundexCodes.Contains(soundex(value))' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression BuildSoundsLikeExpression<T>(Expression<Func<T, string>> stringProperty, IList<string> soundexCodes)
+        {
+            var soundexCallExpresion = Expression.Call(ExpressionMethods.SoundexMethod, stringProperty.Body);
+            var soundexCodesExpression = Expression.Constant(soundexCodes);
+            var containsExpression = Expression.Call(soundexCodesExpression, ExpressionMethods.StringListContainsMethod, soundexCallExpresion);
+            var trueExpression = Expression.Constant(true);
+            return Expression.Equal(containsExpression, trueExpression);
+        }
+
+        /// <summary>
+        /// Build an 'soundexCodes.Contains(reverseSoundex(value))' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression BuildReverseSoundexLikeExpression<T>(Expression<Func<T, string>> stringProperty, IList<string> soundexCodes)
+        {
+            var soundexCallExpresion = Expression.Call(ExpressionMethods.ReverseSoundexMethod, stringProperty.Body);
+            var soundexCodesExpression = Expression.Constant(soundexCodes);
+            var containsExpression = Expression.Call(soundexCodesExpression, ExpressionMethods.StringListContainsMethod, soundexCallExpresion);
+            var trueExpression = Expression.Constant(true);
+            return Expression.Equal(containsExpression, trueExpression);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/StartsWithExpressionBuilder/EnumerableStartsWithExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/StartsWithExpressionBuilder/EnumerableStartsWithExpressionBuilder.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder
+{
+    internal static class EnumerableStartsWithExpressionBuilder
+    {
+        /// <summary>
+        /// Build a 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, IEnumerable<string> searchTerms, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var searchTerm in searchTerms)
+            {
+                var startsWithExpression = Build(stringProperty, searchTerm, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, string searchTerm, SearchOptions searchOptions)
+        {
+            var alteredSearchTerm = searchOptions.SearchType == SearchType.WholeWords ? searchTerm + " " : searchTerm;
+            var searchTermExpression = Expression.Constant(alteredSearchTerm);
+            if (searchOptions.NullCheck)
+            {
+                var coalesceExpression = Expression.Coalesce(stringProperty.Body, ExpressionMethods.EmptyStringExpression);
+                return Expression.Call(coalesceExpression, ExpressionMethods.StartsWithMethodWithComparison, searchTermExpression, searchOptions.ComparisonTypeExpression);
+            }
+
+            return Expression.Call(stringProperty.Body, ExpressionMethods.StartsWithMethodWithComparison, searchTermExpression, searchOptions.ComparisonTypeExpression);
+        }
+
+        /// <summary>
+        /// Build a 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, IEnumerable<Expression<Func<T, string>>> propertiesToSearchFor, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearchFor in propertiesToSearchFor)
+            {
+                var startsWithExpression = Build(stringProperty, propertyToSearchFor, searchOptions.ComparisonTypeExpression);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>> propertyToSearchFor, ConstantExpression stringComparisonExpression, bool nullCheck = true)
+        {
+            var startsWithExpression = Expression.Call(stringProperty.Body, ExpressionMethods.StartsWithMethodWithComparison, propertyToSearchFor.Body, stringComparisonExpression);
+            if (nullCheck)
+            {
+                var stringPropertyNotNullExpression = Expression.NotEqual(stringProperty.Body, ExpressionMethods.NullExpression);
+                var searchForNotNullExpression = Expression.NotEqual(propertyToSearchFor.Body, ExpressionMethods.NullExpression);
+                var propertiesNotNullExpression = Expression.AndAlso(stringPropertyNotNullExpression, searchForNotNullExpression);
+                return Expression.AndAlso(propertiesNotNullExpression, startsWithExpression);
+            }
+            return startsWithExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, string[] searchTerms, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var startsWithExpression = Build(stringProperty, searchTerms, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, Expression<Func<T, string>>[] propertiesToSearchFor, SearchOptions searchOptions)
+        {
+            Expression completeExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var startsWithExpression = Build(stringProperty, propertiesToSearchFor, searchOptions);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/StartsWithExpressionBuilder/QueryableStartsWithExpressionBuilder.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/ExpressionBuilders/StartsWithExpressionBuilder/QueryableStartsWithExpressionBuilder.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder
+{
+    internal static class QueryableStartsWithExpressionBuilder
+    {
+        /// <summary>
+        /// Build a 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, string[] searchTerms, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            foreach (var property in stringProperties)
+            {
+                var startsWithExpression = Build(property, searchTerms, searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build a 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>> stringProperty, IEnumerable<string> searchTerms, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            foreach (var searchTerm in searchTerms)
+            {
+                var startsWithExpression = Build(stringProperty, searchTerm, searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, string searchTerm, SearchType searchType)
+        {
+            var paddedTerm = searchType == SearchType.WholeWords ? searchTerm + " " : searchTerm;
+            var searchTermExpression = Expression.Constant(paddedTerm);
+            return Expression.Call(stringProperty.Body, ExpressionMethods.StartsWithMethod, searchTermExpression);
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        public static Expression Build<T>(Expression<Func<T, string>>[] stringProperties, Expression<Func<T, string>>[] propertiesToSearchFor, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            foreach (var stringProperty in stringProperties)
+            {
+                var startsWithExpression = Build(stringProperty, propertiesToSearchFor, searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>>[] propertiesToSearchFor, SearchType searchType)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearchFor in propertiesToSearchFor)
+            {
+                var startsWithExpression = Build(stringProperty, propertyToSearchFor, searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            return completeExpression;
+        }
+
+        /// <summary>
+        /// Build an 'indexof() == 0' expression for a search term against a particular string property
+        /// </summary>
+        private static Expression Build<T>(Expression<Func<T, string>> stringProperty, Expression<Func<T, string>> propertyToSearchFor, SearchType searchType)
+        {
+            var paddedTerm = propertyToSearchFor.Body;
+            if (searchType == SearchType.WholeWords)
+            {
+                var seperator = Expression.Constant(" ");
+                paddedTerm = Expression.Call(ExpressionMethods.StringConcatMethod, propertyToSearchFor.Body, seperator);
+            }
+
+            var result = Expression.Call(stringProperty.Body, ExpressionMethods.StartsWithMethod, paddedTerm);
+            if (searchType == SearchType.WholeWords)
+            {
+                var isEqualExpression = QueryableEqualsExpressionBuilder.Build(stringProperty, propertyToSearchFor);
+                return ExpressionHelper.JoinOrExpression(result, isEqualExpression);
+            }
+
+            return result;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Helpers/StringExtensions.cs
+++ b/NinjaNye.SearchExtensions.Portable/Helpers/StringExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Globalization;
+
+namespace NinjaNye.SearchExtensions.Portable.Helpers
+{
+    public static class StringExtensionHelper
+    {
+        public static string Replace(this string text, string oldValue, string newValue, StringComparison stringComparison)
+        {
+            int position;
+            while ((position = text.IndexOf(oldValue, stringComparison)) > -1)
+            {
+                text = text.Remove(position, oldValue.Length);
+                text = text.Insert(position, newValue);
+            }
+            return text;
+        }
+
+        public static string GetFirstCharacter(this string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return null;
+            }
+
+            return text.TrimStart()[0].ToString();
+        }
+
+        public static string QuickReverse(this string value)
+        {
+            var charArray = value.ToCharArray();
+            Array.Reverse(charArray);
+            return new string(charArray);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Levenshtein/LevenshteinDistance.cs
+++ b/NinjaNye.SearchExtensions.Portable/Levenshtein/LevenshteinDistance.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NinjaNye.SearchExtensions.Portable.Levenshtein
+{
+    public interface ILevenshteinDistance<out T>
+    {
+        int Distance { get; }
+
+        /// <summary>
+        /// The queried item
+        /// </summary>
+        T Item { get; }
+        
+        /// <summary>
+        /// A collection of all distances calculated
+        /// </summary>
+        int[] Distances { get; }
+
+        /// <summary>
+        /// The minimum distance of all levenshtein calculations
+        /// </summary>
+        int MinimumDistance { get; }
+
+        /// <summary>
+        /// The maximum distance of all levenshtein calculations
+        /// </summary>
+        int MaximumDistance { get; }
+    }
+
+    internal class LevenshteinDistance<T> : ILevenshteinDistance<T>
+    {
+        public LevenshteinDistance(T item, params int[] distances)
+        {
+            Item = item;
+            Distances = distances;
+        }
+
+        public int Distance => Distances.First();
+        public T Item { get; }
+        public int[] Distances { get; }
+
+        public int MinimumDistance => Distances.Min();
+        public int MaximumDistance => Distances.Max();
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Levenshtein/LevenshteinProcessor.cs
+++ b/NinjaNye.SearchExtensions.Portable/Levenshtein/LevenshteinProcessor.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Globalization;
+
+namespace NinjaNye.SearchExtensions.Portable.Levenshtein
+{
+    public static class LevenshteinProcessor
+    {
+        /// <summary>
+        /// Compute the Levenshtein Distance between two strings.
+        /// </summary>
+        /// <param name="source">Source string to compare</param>
+        /// <param name="comparedTo">String to compare to source</param>
+        /// <returns>Calculated Levenshtein Distance</returns>
+        public static int LevenshteinDistance(string source, string comparedTo)
+        {
+            bool nullSource = source == null;
+            bool nullCompare = comparedTo == null;
+            if (nullSource && nullCompare)
+            {
+                return 0;
+            }
+
+            if (nullSource)
+            {
+                return comparedTo.Length;
+            }
+
+            if (nullCompare)
+            {
+                return source.Length;
+            }
+
+            if (source.Equals(comparedTo, StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            return ComputeDistance(source, comparedTo);
+        }
+
+        private static int ComputeDistance(string source, string comparedTo)
+        {
+            int sourceLength = source.Length + 1;
+            var textInfo = CultureInfo.CurrentCulture.TextInfo;
+            source = textInfo.ToLower(source).PadLeft(sourceLength);
+            comparedTo = textInfo.ToLower(comparedTo);
+            var previousValues = new int[sourceLength];
+            var currentValues = new int[sourceLength];
+            for (int row = 0; row < sourceLength; row++)
+            {
+                previousValues[row] = row;
+            }
+
+            for (int column = 0; column < comparedTo.Length; column++)
+            {
+                bool isFirst = true;
+                char comparedToCharacter = comparedTo[column];
+                for (int row = 0; row < sourceLength; row++)
+                {
+                    int minimumCost = previousValues[row] + 1;
+                    if (!isFirst)
+                    {
+                        int cost = source[row] != comparedToCharacter ? 1 : 0;
+                        var previousRow = row - 1;
+                        int diagonalIncrement = previousValues[previousRow] + cost;
+                        int topIncrement = currentValues[previousRow] + 1;
+                        minimumCost = Math.Min(Math.Min(diagonalIncrement, topIncrement), minimumCost);
+                    }
+                    currentValues[row] = minimumCost;
+                    isFirst = false;
+                }
+
+                previousValues = currentValues;
+                currentValues = new int[sourceLength];
+            }
+            return previousValues[source.Length - 1];
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Models/Ranked.cs
+++ b/NinjaNye.SearchExtensions.Portable/Models/Ranked.cs
@@ -1,0 +1,14 @@
+namespace NinjaNye.SearchExtensions.Portable.Models
+{
+    public interface IRanked<out T>
+    {
+        int Hits { get; }
+        T Item { get; }
+    }
+
+    internal class Ranked<T> : IRanked<T>
+    {
+        public int Hits { get; set; }
+        public T Item { get; set; }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/NinjaNye.SearchExtensions.Portable.csproj
+++ b/NinjaNye.SearchExtensions.Portable/NinjaNye.SearchExtensions.Portable.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{8EB3D1B8-0592-471A-829B-B7C776C37CAA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>NinjaNye.SearchExtensions.Portable</RootNamespace>
+    <AssemblyName>NinjaNye.SearchExtensions.Portable</AssemblyName>
+    <DefaultLanguage>en-US</DefaultLanguage>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- A reference to the entire .NET Framework is automatically included -->
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ChildSearchBase.cs" />
+    <Compile Include="EnumerableChildSearch.cs" />
+    <Compile Include="EnumerableChildSearchBase.cs" />
+    <Compile Include="EnumerableChildSelector.cs" />
+    <Compile Include="EnumerableChildStringSearch.cs" />
+    <Compile Include="EnumerableLevenshteinCompare.cs" />
+    <Compile Include="EnumerableLevenshteinSearch.cs" />
+    <Compile Include="EnumerableSearchBase.cs" />
+    <Compile Include="EnumerableSoundexSearch.cs" />
+    <Compile Include="EnumerableStringSearch.cs" />
+    <Compile Include="EnumerableStructSearch.cs" />
+    <Compile Include="FluentChildSearch.cs" />
+    <Compile Include="FluentLevenshteinSearch.cs" />
+    <Compile Include="FluentSearch.cs" />
+    <Compile Include="FluentStringSearch.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\ContainsExpressionBuilder\EnumerableContainsExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\ContainsExpressionBuilder\QueryableContainsExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\EndsWithExpressionBuilder\EnumerableEndsWithExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\EndsWithExpressionBuilder\QueryableEndsWithExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\EnumerableExpressionHelper.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\EqualsExpressionBuilder\EnumerableEqualsExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\EqualsExpressionBuilder\ExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\EqualsExpressionBuilder\QueryableEqualsExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\ExpressionHelper.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\ExpressionMethods.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\SoundexExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\StartsWithExpressionBuilder\EnumerableStartsWithExpressionBuilder.cs" />
+    <Compile Include="Helpers\ExpressionBuilders\StartsWithExpressionBuilder\QueryableStartsWithExpressionBuilder.cs" />
+    <Compile Include="Helpers\StringExtensions.cs" />
+    <Compile Include="Levenshtein\LevenshteinDistance.cs" />
+    <Compile Include="Levenshtein\LevenshteinProcessor.cs" />
+    <Compile Include="Models\Ranked.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="QueryableChildSearch.cs" />
+    <Compile Include="QueryableChildSearchBase.cs" />
+    <Compile Include="QueryableChildSelector.cs" />
+    <Compile Include="QueryableChildStringSearch.cs" />
+    <Compile Include="QueryableSearchBase.cs" />
+    <Compile Include="QueryableStringSearch.cs" />
+    <Compile Include="QueryableStructSearch.cs" />
+    <Compile Include="SearchBase.cs" />
+    <Compile Include="SearchOptions.cs" />
+    <Compile Include="SearchTermCollection.cs" />
+    <Compile Include="SearchType.cs" />
+    <Compile Include="Soundex\SoundexProcessor.cs" />
+    <Compile Include="Validation\Ensure.cs" />
+    <Compile Include="Visitors\SwapExpressionVisitor.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/NinjaNye.SearchExtensions.Portable/Properties/AssemblyInfo.cs
+++ b/NinjaNye.SearchExtensions.Portable/Properties/AssemblyInfo.cs
@@ -1,0 +1,30 @@
+﻿using System.Resources;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("NinjaNye.SearchExtensions.Portable")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("LHP")]
+[assembly: AssemblyProduct("NinjaNye.SearchExtensions.Portable")]
+[assembly: AssemblyCopyright("Copyright © LHP 2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/NinjaNye.SearchExtensions.Portable/QueryableChildSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableChildSearch.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class QueryableChildSearch<TParent, TChild, TProperty> : QueryableChildSearchBase<TParent, TChild, TProperty>
+    {
+        public QueryableChildSearch(IQueryable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties) 
+            : base(parent, childProperties, properties, null, null)
+        {
+        }
+
+        public QueryableChildSearch(IQueryable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties, Expression completeExpression, ParameterExpression childParameter)
+            : base(parent, childProperties, properties, completeExpression, childParameter)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are equal to any of the supplied <paramref name="values">values</paramref> 
+        /// </summary>
+        /// <param name="values">A collection of values to match upon</param>
+        public QueryableChildSearch<TParent, TChild, TProperty> EqualTo(params TProperty[] values)
+        {
+            AppendExpression(ExpressionBuilder.EqualsExpression(Properties, values));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than any of the supplied <paramref name="value">value</paramref> 
+        /// </summary>
+        /// <param name="value">A collection of values to match upon</param>
+        public QueryableChildSearch<TParent, TChild, TProperty> GreaterThan(TProperty value)
+        {
+            AppendExpression(ExpressionBuilder.GreaterThanExpression(Properties, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than or equal to any of the supplied <paramref name="value">value</paramref> 
+        /// </summary>
+        /// <param name="value">A collection of values to match upon</param>
+        public QueryableChildSearch<TParent, TChild, TProperty> GreaterThanOrEqualTo(TProperty value)
+        {
+            AppendExpression(ExpressionBuilder.GreaterThanOrEqualExpression(Properties, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than any of the supplied <paramref name="value">value</paramref> 
+        /// </summary>
+        /// <param name="value">A collection of values to match upon</param>
+        public QueryableChildSearch<TParent, TChild, TProperty> LessThan(TProperty value)
+        {
+            AppendExpression(ExpressionBuilder.LessThanExpression(Properties, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than any of the supplied <paramref name="value">value</paramref> 
+        /// </summary>
+        /// <param name="value">A collection of values to match upon</param>
+        public QueryableChildSearch<TParent, TChild, TProperty> LessThanOrEqualTo(TProperty value)
+        {
+            AppendExpression(ExpressionBuilder.LessThanOrEqualExpression(Properties, value));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than any of the supplied <paramref name="value">value</paramref> 
+        /// </summary>
+        public QueryableChildSearch<TParent, TChild, TProperty> Between(TProperty minvalue, TProperty maxValue)
+        {
+            AppendExpression(ExpressionBuilder.BetweenExpression(Properties, minvalue, maxValue));
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/QueryableChildSearchBase.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableChildSearchBase.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public abstract class QueryableChildSearchBase<TParent, TChild, TProperty> : ChildSearchBase<TParent, TChild, TProperty>, IQueryable<TParent>
+    {
+        private readonly IQueryable<TParent> _parent;
+
+        protected QueryableChildSearchBase(IQueryable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, TProperty>>[] properties, Expression completeExpression, ParameterExpression childParamerter)
+            : base(childProperties, properties, completeExpression, childParamerter)
+        {
+            Expression = parent.Expression;
+            ElementType = parent.ElementType;
+            Provider = parent.Provider;
+            _parent = parent;
+        }
+
+        /// <summary>
+        /// Begin a search against a new property.
+        /// </summary>
+        public QueryableChildSearch<TParent, TChild, TAnotherProperty> With<TAnotherProperty>(params Expression<Func<TChild, TAnotherProperty>>[] properties)
+        {
+            return new QueryableChildSearch<TParent, TChild, TAnotherProperty>(_parent, _childProperties, properties, _completeExpression, _childParameter);            
+        }
+
+        /// <summary>
+        /// Begin a search against a new string property.
+        /// </summary>
+        public QueryableChildStringSearch<TParent, TChild> With(params Expression<Func<TChild, string>>[] properties)
+        {
+            return new QueryableChildStringSearch<TParent, TChild>(_parent, _childProperties, properties, _completeExpression, _childParameter);            
+        }
+        public IEnumerator<TParent> GetEnumerator()
+        {
+            var final = BuildFinalExpression();
+            return _parent.Where(final).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public Expression Expression { get; private set; }
+
+        public Type ElementType { get; private set; }
+
+        public IQueryProvider Provider { get; private set; }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/QueryableChildSelector.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableChildSelector.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class QueryableChildSelector<TBase, TChild> : IQueryable<TBase>
+    {
+        private readonly IQueryable<TBase> _parent;
+        private readonly Expression<Func<TBase, IEnumerable<TChild>>>[] _childProperties;
+
+        public QueryableChildSelector(IQueryable<TBase> parent, Expression<Func<TBase, IEnumerable<TChild>>>[] childProperties)
+        {
+            _parent = parent;
+            _childProperties = childProperties;
+            Provider = _parent.Provider;
+            ElementType = _parent.ElementType;
+            Expression = _parent.Expression;
+        }
+
+        public QueryableChildSearch<TBase, TChild, TProperty> With<TProperty>(params Expression<Func<TChild, TProperty>>[] properties)
+        {
+            return new QueryableChildSearch<TBase, TChild, TProperty>(_parent, _childProperties, properties);
+        }
+
+        public QueryableChildStringSearch<TBase, TChild> With(params Expression<Func<TChild, string>>[] properties)
+        {
+            return new QueryableChildStringSearch<TBase, TChild>(_parent, _childProperties, properties);
+        }
+
+        public IEnumerator<TBase> GetEnumerator()
+        {
+            return _parent.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public Expression Expression { get; private set; }
+        public Type ElementType { get; private set; }
+        public IQueryProvider Provider { get; private set; }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/QueryableChildStringSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableChildStringSearch.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.ContainsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class QueryableChildStringSearch<TParent, TChild> : QueryableChildSearchBase<TParent, TChild, string>
+    {
+        private readonly SearchOptions _searchOptions = new SearchOptions();
+
+        public QueryableChildStringSearch(IQueryable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, string>>[] properties)
+            : base(parent, childProperties, properties, null, null)
+        {
+        }
+
+        public QueryableChildStringSearch(IQueryable<TParent> parent, Expression<Func<TParent, IEnumerable<TChild>>>[] childProperties, Expression<Func<TChild, string>>[] properties, Expression completeExpression, ParameterExpression childParameter)
+            : base(parent, childProperties, properties, completeExpression, childParameter)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are equal to any of the supplied <paramref name="values">values</paramref> 
+        /// </summary>
+        /// <param name="values">A collection of values to match upon</param>
+        public QueryableChildStringSearch<TParent, TChild> EqualTo(params string[] values)
+        {
+            AppendExpression(ExpressionBuilder.EqualsExpression(Properties, values));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// contain any of the supplied <paramref name="values">values</paramref> 
+        /// </summary>
+        /// <param name="values">A collection of values to match upon</param>
+        public QueryableChildStringSearch<TParent, TChild> Containing(params string[] values)
+        {
+            AppendExpression(QueryableContainsExpressionBuilder.Build(Properties, values, _searchOptions.SearchType));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// contain all of the supplied <paramref name="values">values</paramref> 
+        /// </summary>
+        /// <param name="values">A collection of values to match upon</param>
+        public QueryableChildStringSearch<TParent, TChild> ContainingAll(params string[] values)
+        {
+            for (int i = 0; i < values.Length; i++)
+            {
+                Containing(values[i]);
+            }
+
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties starts 
+        /// with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableChildStringSearch<TParent, TChild> StartsWith(params string[] terms)
+        {
+            AppendExpression(QueryableStartsWithExpressionBuilder.Build(Properties, terms, _searchOptions.SearchType));
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties ends 
+        /// with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableChildStringSearch<TParent, TChild> EndsWith(params string[] terms)
+        {
+            AppendExpression(QueryableEndsWithExpressionBuilder.Build(Properties, terms, _searchOptions.SearchType));
+            return this;
+        }
+
+        public QueryableChildStringSearch<TParent, TChild> Matching(SearchType searchType)
+        {
+            _searchOptions.SearchType = searchType;
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/QueryableSearchBase.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableSearchBase.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class QueryableSearchBase<TSource, TProperty> 
+        : SearchBase<IQueryable<TSource>, TSource, TProperty>, IQueryable<TSource>
+    {
+        private bool _expressionUpdated;
+
+        protected QueryableSearchBase(IQueryable<TSource> source, Expression<Func<TSource, TProperty>>[] properties)
+            : base(source, properties)
+        {
+            ElementType = source.ElementType;
+            Provider = source.Provider;
+        }
+
+        public Expression Expression
+        {
+            get
+            {
+                UpdateSource();
+                return Source.Expression;
+            }
+        }
+
+        public Type ElementType { get; private set; }
+        public IQueryProvider Provider { get; private set; }
+
+        protected override void BuildExpression(Expression expressionToJoin)
+        {
+            _expressionUpdated = false;
+            base.BuildExpression(expressionToJoin);
+        }
+
+        private void UpdateSource()
+        {
+            if (CompleteExpression == null || _expressionUpdated)
+            {
+                return;
+            }
+
+            _expressionUpdated = true;
+            var finalExpression = Expression.Lambda<Func<TSource, bool>>(CompleteExpression, FirstParameter);
+            Source = Source.Where(finalExpression);
+        }
+
+        protected void QueryInclude(string path)
+        {
+            var includeMethod = Source.GetType().GetRuntimeMethod("Include", new[] {typeof(string)});
+            Source = (IQueryable<TSource>) includeMethod?.Invoke(Source, new[] {path});
+        }
+
+        public IEnumerator<TSource> GetEnumerator()
+        {
+            UpdateSource();
+            return Source.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/QueryableStringSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableStringSearch.cs
@@ -1,0 +1,246 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.ContainsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EndsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.StartsWithExpressionBuilder;
+using NinjaNye.SearchExtensions.Portable.Models;
+using NinjaNye.SearchExtensions.Portable.Validation;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class QueryableStringSearch<T> : QueryableSearchBase<T, string>
+    {
+        private readonly ISearchTermCollection _searchTerms = new SearchTermCollection();
+        private SearchType _searchType;
+
+        public QueryableStringSearch(IQueryable<T> source, Expression<Func<T, string>>[] stringProperties)
+            : base(source, stringProperties)
+        {
+        }
+
+        public IQueryable<T> Include(string path)
+        {
+            QueryInclude(path);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableStringSearch<T> Containing(params string[] terms)
+        {
+            Ensure.ArgumentNotNull(terms, "terms");
+            var validSearchTerms = StoreSearchTerms(terms);
+
+            var orExpression = QueryableContainsExpressionBuilder.Build(Properties, validSearchTerms, _searchType);
+            BuildExpression(orExpression);
+            return this;
+        }
+
+        private string[] StoreSearchTerms(string[] terms)
+        {
+            var validSearchTerms = terms.Where(s => !String.IsNullOrWhiteSpace(s)).ToArray();
+            _searchTerms.Add(validSearchTerms);
+            return validSearchTerms;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableStringSearch<T> Containing(params Expression<Func<T, string>>[] terms)
+        {
+            Expression finalExpression = null;
+            foreach (var propertyToSearch in Properties)
+            {
+                var searchTermProperty = AlignParameter(terms[0]);
+                Expression comparisonExpression = QueryableContainsExpressionBuilder.Build(propertyToSearch, searchTermProperty);
+                finalExpression = ExpressionHelper.JoinOrExpression(finalExpression, comparisonExpression);
+            }
+            BuildExpression(finalExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where *all* of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableStringSearch<T> ContainingAll(params string[] terms)
+        {
+            var result = this;
+            foreach (var term in terms)
+            {
+                result = result.Containing(term);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieve items where *all* of the defined terms are contained 
+        /// within any of the defined properties
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Term or terms to search for</param>
+        public QueryableStringSearch<T> ContainingAll(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            var result = this;
+            foreach (var propertyToSearchFor in propertiesToSearchFor)
+            {
+                result = result.Containing(propertyToSearchFor);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// starts with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableStringSearch<T> StartsWith(params string[] terms)
+        {
+            _searchTerms.Add(terms);
+            Expression completeExpression = null;
+            foreach (var propertyToSearch in Properties)
+            {
+                var startsWithExpression = QueryableStartsWithExpressionBuilder.Build(propertyToSearch, terms, _searchType);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, startsWithExpression);
+            }
+            BuildExpression(completeExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// starts with any of the defined terms
+        /// </summary>
+        /// <param name="propertiesToSearchFor">properties defining the terms to search for</param>
+        public QueryableStringSearch<T> StartsWith(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            var propertiesToSearch = propertiesToSearchFor.Select(AlignParameter).ToArray();
+            var completeExpression = QueryableStartsWithExpressionBuilder.Build(Properties, propertiesToSearch, _searchType);
+            BuildExpression(completeExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// ends with any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableStringSearch<T> EndsWith(params string[] terms)
+        {
+            _searchTerms.Add(terms);
+            var endsWithExpression = QueryableEndsWithExpressionBuilder.Build(Properties, terms, _searchType);
+            BuildExpression(endsWithExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// ends with any of the defined terms
+        /// </summary>
+        /// <param name="propertiesToSearchFor">properties defining the terms to search for</param>
+        public QueryableStringSearch<T> EndsWith(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            var propertiesToSearch = propertiesToSearchFor.Select(AlignParameter).ToArray();
+            var endsWithExpression = QueryableEndsWithExpressionBuilder.Build(Properties, propertiesToSearch, _searchType);
+            BuildExpression(endsWithExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined properties 
+        /// are equal to any of the defined search terms
+        /// </summary>
+        /// <param name="terms">Term or terms to search for</param>
+        public QueryableStringSearch<T> EqualTo(params string[] terms)
+        {
+            Expression completeExpression = QueryableEqualsExpressionBuilder.Build(Properties, terms);
+            BuildExpression(completeExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieve items where any of the defined search properties 
+        /// are equal to any of the properties supplied
+        /// </summary>
+        /// <param name="propertiesToSearchFor">Properties to match against</param>
+        public QueryableStringSearch<T> EqualTo(params Expression<Func<T, string>>[] propertiesToSearchFor)
+        {
+            Expression completeExpression = null;
+            foreach (var propertyToSearch in Properties)
+            {
+                var alignedProperties = propertiesToSearchFor.Select(AlignParameter).ToArray();
+                var isEqualExpression = QueryableEqualsExpressionBuilder.Build(propertyToSearch, alignedProperties);
+                completeExpression = ExpressionHelper.JoinOrExpression(completeExpression, isEqualExpression);
+            }
+
+            BuildExpression(completeExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Returns Enumerable of records that match the Soundex code for
+        /// any of the given terms across any of the defined properties
+        /// </summary>
+        /// <param name="terms">terms to search for</param>
+        /// <returns>Enumerable of records where Soundex matches</returns>
+        public IEnumerable<T> Soundex(params string[] terms)
+        {
+            var firstCharacters = terms.Select(t => t.GetFirstCharacter())
+                                       .Distinct()
+                                       .ToArray();
+            return StartsWith(firstCharacters).AsEnumerable()
+                       .Search(Properties).Soundex(terms);
+        }
+
+        /// <summary>
+        /// Rank the filtered items based on the matched occurences
+        /// </summary>
+        /// <returns>
+        /// Queryable ranked items.  Each item will contain 
+        /// the amount of hits found across the defined properties.
+        /// </returns>
+        /// <remarks>Only works in conjunction with string searches</remarks>
+        public IQueryable<IRanked<T>> ToRanked()
+        {
+            Expression combinedHitExpression = null;
+            foreach (var propertyToSearch in Properties)
+            {
+                var nullSafeExpression = BuildNullSafeExpression(propertyToSearch);
+                for (int j = 0; j < _searchTerms.Count; j++)
+                {
+                    var searchTerm = _searchTerms[j];
+                    var hitCountExpression = EnumerableExpressionHelper.CalculateHitCount(nullSafeExpression, searchTerm);
+                    combinedHitExpression = ExpressionHelper.AddExpressions(combinedHitExpression, hitCountExpression);
+                }
+            }
+
+            var rankedInitExpression = EnumerableExpressionHelper.ConstructRankedResult<T>(combinedHitExpression, FirstParameter);
+            var selectExpression = Expression.Lambda<Func<T, Ranked<T>>>(rankedInitExpression, FirstParameter);
+            return this.Select(selectExpression);
+        }
+
+        private Expression<Func<T, string>> BuildNullSafeExpression(Expression<Func<T, string>> propertyToSearch)
+        {
+            var nullSafeProperty = Expression.Coalesce(propertyToSearch.Body, ExpressionMethods.EmptyStringExpression);
+            var nullSafeExpression = Expression.Lambda<Func<T, string>>(nullSafeProperty, FirstParameter);
+            return nullSafeExpression;
+        }
+
+        public QueryableStringSearch<T> Matching(SearchType searchType)
+        {
+            _searchType = searchType;
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/QueryableStructSearch.cs
+++ b/NinjaNye.SearchExtensions.Portable/QueryableStructSearch.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders.EqualsExpressionBuilder;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class QueryableStructSearch<TSource, TProperty> : QueryableSearchBase<TSource, TProperty>
+        where TProperty : struct
+    {
+        public QueryableStructSearch(IQueryable<TSource> source, Expression<Func<TSource, TProperty>>[] properties)
+            : base(source, properties)
+        {
+        }
+
+        public IQueryable<TSource> Include(string path)
+        {
+            QueryInclude(path);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// equal any of the supplied values
+        /// </summary>
+        /// <param name="values">Values to search for</param>
+        public QueryableStructSearch<TSource, TProperty> EqualTo(params TProperty[] values)
+        {
+            var equalsExpression = ExpressionBuilder.EqualsExpression(Properties, values);
+            BuildExpression(equalsExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public QueryableStructSearch<TSource, TProperty> GreaterThan(TProperty value)
+        {
+            var greaterThanExpression = ExpressionBuilder.GreaterThanExpression(Properties, value);
+            BuildExpression(greaterThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are less than any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public QueryableStructSearch<TSource, TProperty> LessThan(TProperty value)
+        {
+            var greaterThanExpression = ExpressionBuilder.LessThanExpression(Properties, value);
+            BuildExpression(greaterThanExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are less than or equal to any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public QueryableStructSearch<TSource, TProperty> LessThanOrEqualTo(TProperty value)
+        {
+            var lessThanOrEqualExpression = ExpressionBuilder.LessThanOrEqualExpression(Properties, value);
+            BuildExpression(lessThanOrEqualExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than or equal to any of the supplied value
+        /// </summary>
+        /// <param name="value">Value to search for</param>
+        public QueryableStructSearch<TSource, TProperty> GreaterThanOrEqualTo(TProperty value)
+        {
+            var greaterThanOrEqualExpression = ExpressionBuilder.GreaterThanOrEqualExpression(Properties, value);
+            BuildExpression(greaterThanOrEqualExpression);
+            return this;
+        }
+
+        /// <summary>
+        /// Retrieves items where any of the defined properties
+        /// are greater than <paramref name="minValue">minValue</paramref> 
+        /// AND less than <paramref name="maxValue">maxValue</paramref> 
+        /// </summary>
+        public QueryableStructSearch<TSource, TProperty> Between(TProperty minValue, TProperty maxValue)
+        {
+            var betweenExpression = ExpressionBuilder.BetweenExpression(Properties, minValue, maxValue);
+            BuildExpression(betweenExpression);
+            return this;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/SearchBase.cs
+++ b/NinjaNye.SearchExtensions.Portable/SearchBase.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Portable.Helpers.ExpressionBuilders;
+using NinjaNye.SearchExtensions.Portable.Visitors;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public abstract class SearchBase<TSource, TType, TPropertyType> where TSource : IEnumerable<TType>
+    {
+        protected TSource Source;
+        protected Expression CompleteExpression;
+        protected readonly Expression<Func<TType, TPropertyType>>[] Properties;
+        protected readonly ParameterExpression FirstParameter;
+
+        protected SearchBase(TSource source, Expression<Func<TType, TPropertyType>>[] properties)
+        {
+            Source = source;
+            var firstProperty = properties.FirstOrDefault();
+            if (firstProperty != null)
+            {
+                FirstParameter = firstProperty.Parameters[0];
+            }
+            Properties = properties.Select(AlignParameter).ToArray();
+        }
+
+        /// <summary>
+        /// Appends expressionToJoin to CompleteExpression using an Expression.AndAlso join
+        /// </summary>
+        protected virtual void BuildExpression(Expression expressionToJoin)
+        {
+            CompleteExpression = ExpressionHelper.JoinAndAlsoExpression(CompleteExpression, expressionToJoin);
+        }
+
+        /// <summary>
+        /// Align the lambda parameter to that of the first string property
+        /// </summary>
+        protected Expression<TProperty> AlignParameter<TProperty>(Expression<TProperty> lambda)
+        {
+            return SwapExpressionVisitor.Swap(lambda, lambda.Parameters.Single(), FirstParameter);
+        }
+    }
+
+}

--- a/NinjaNye.SearchExtensions.Portable/SearchOptions.cs
+++ b/NinjaNye.SearchExtensions.Portable/SearchOptions.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    public class SearchOptions
+    {
+        private StringComparison _comparisonType;
+        private ConstantExpression _comparisonTypeExpression;
+
+        public SearchOptions()
+        {
+            NullCheck = true;
+            SearchType = SearchType.AnyOccurrence;
+            ComparisonType = StringComparison.CurrentCulture;
+        }
+
+        public bool NullCheck { get; private set; }
+
+        public SearchType SearchType { get; set; }
+
+        public StringComparison ComparisonType
+        {
+            get { return _comparisonType; }
+            set
+            {
+                _comparisonType = value;
+                _comparisonTypeExpression = Expression.Constant(value);
+            }
+        }
+
+        public ConstantExpression ComparisonTypeExpression => _comparisonTypeExpression;
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/SearchTermCollection.cs
+++ b/NinjaNye.SearchExtensions.Portable/SearchTermCollection.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace NinjaNye.SearchExtensions.Portable
+{
+    internal interface ISearchTermCollection : IEnumerable<string>
+    {
+        void Add(string term);
+        void Add(IEnumerable<string> terms);
+        int Count { get; }
+        string this[int index] { get; }
+    }
+
+    internal class SearchTermCollection : ISearchTermCollection
+    {
+        private readonly IList<string> _terms;
+
+        public string this[int index] => _terms[index];
+        /// <returns>
+        /// Gets the number of elements contained in the SearchCollection
+        /// </returns>
+        public int Count => _terms.Count;
+
+        public SearchTermCollection()
+        {
+            _terms = new List<string>();
+        }
+
+        public void Add(string term)
+        {
+            if (IsValid(term))
+            {
+                _terms.Add(term);
+            }
+        }
+
+        private static bool IsValid(string term)
+        {
+            return !string.IsNullOrWhiteSpace(term);
+        }
+
+        public void Add(IEnumerable<string> terms)
+        {
+            foreach (var term in terms)
+            {
+                Add(term);
+            }
+        }
+
+        public IEnumerator<string> GetEnumerator()
+        {
+            return _terms.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/SearchType.cs
+++ b/NinjaNye.SearchExtensions.Portable/SearchType.cs
@@ -1,0 +1,8 @@
+﻿namespace NinjaNye.SearchExtensions.Portable
+{
+    public enum SearchType
+    {
+        AnyOccurrence,
+        WholeWords
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Soundex/SoundexProcessor.cs
+++ b/NinjaNye.SearchExtensions.Portable/Soundex/SoundexProcessor.cs
@@ -1,0 +1,122 @@
+﻿using System.Globalization;
+using System.Text;
+using NinjaNye.SearchExtensions.Portable.Helpers;
+
+namespace NinjaNye.SearchExtensions.Portable.Soundex
+{
+    public static class SoundexProcessor
+    {
+        private const int maxSoundexLength = 4;
+
+        /// <summary>
+        /// Retrieve the Soundex value for a given string
+        /// Soundex used is American Soundex as defined
+        /// on http://en.wikipedia.org/wiki/Soundex  
+        /// </summary>
+        /// <param name="value">string to transform into soundex code</param>
+        /// <returns>Soundex code for the given string</returns>
+        public static string ToSoundex(this string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            var sb = BuildRawSoundex(value);
+            ValidateLength(sb);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Retrieve the Soundex value for a given string.
+        /// Soundex used is Reverse Soundex which produces 
+        /// a soundex code on the reverse of the supplied string
+        /// </summary>
+        /// <param name="value">string to transform into reverse soundex code</param>
+        /// <returns>Reverse Soundex code for the given string</returns>
+        public static string ToReverseSoundex(this string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return string.Empty;
+            }
+
+            value = value.QuickReverse();
+            var sb = BuildRawSoundex(value);
+            ValidateLength(sb);
+            return sb.ToString();
+        }
+
+        private static StringBuilder BuildRawSoundex(string value)
+        {
+            char firstCharacter = CultureInfo.InvariantCulture.TextInfo.ToUpper(value[0]);
+            var sb = new StringBuilder(4);
+            sb.Append(firstCharacter);
+            string previousSoundex = firstCharacter.GetSoundex();
+            for (int i = 1; i < value.Length; i++)
+            {
+                var character = value[i];
+                string soundex = character.GetSoundex();
+                if (soundex != previousSoundex)
+                {
+                    sb.Append(soundex);
+                    if (sb.Length == maxSoundexLength)
+                    {
+                        return sb;
+                    }
+
+                    if (!character.IsHOrW())
+                    {
+                        previousSoundex = soundex;
+                    }
+                }
+            }
+            return sb;
+        }
+
+        // ReSharper disable once InconsistentNaming
+        private static bool IsHOrW(this char character)
+        {
+            return character == 'h' || character == 'i' 
+                || character == 'H' || character == 'I';
+        }
+
+        private static string GetSoundex(this char character)
+        {
+            switch (character)
+            {
+                case 'b': case 'f': case 'p': case 'v':
+                case 'B': case 'F': case 'P': case 'V':
+                    return "1";
+                case 'c': case 'g': case 'j': case 'k':
+                case 'q': case 's': case 'x': case 'z':
+                case 'C': case 'G': case 'J': case 'K':
+                case 'Q': case 'S': case 'X': case 'Z':
+                    return "2";
+                case 'd': case 't': case 'D': case 'T':
+                    return "3";
+                case 'l': case 'L':
+                    return "4";
+                case 'm': case 'n': case 'M': case 'N':
+                    return "5";
+                case 'r': case 'R':
+                    return "6";
+                default:
+                    return string.Empty;
+            }
+        }
+
+        private static void ValidateLength(this StringBuilder stringBuilder)
+        {
+            int soundexLength = stringBuilder.Length;
+            if (soundexLength < maxSoundexLength)
+            {
+                int zerosToAdd = maxSoundexLength - soundexLength;
+                for (int i = 0; i < zerosToAdd; i++)
+                {
+                    stringBuilder.Append('0');
+                }
+            }
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Validation/Ensure.cs
+++ b/NinjaNye.SearchExtensions.Portable/Validation/Ensure.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace NinjaNye.SearchExtensions.Portable.Validation
+{
+    internal static class Ensure
+    {
+        /// <summary>
+        /// Ensures an argument is not null
+        /// </summary>
+        /// <param name="value">Argument value to check</param>
+        /// <param name="paramName">Argument name</param>
+        public static void ArgumentNotNull(object value, string paramName)
+        {
+            if (value == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Portable/Visitors/SwapExpressionVisitor.cs
+++ b/NinjaNye.SearchExtensions.Portable/Visitors/SwapExpressionVisitor.cs
@@ -1,0 +1,36 @@
+using System.Linq.Expressions;
+
+namespace NinjaNye.SearchExtensions.Portable.Visitors
+{
+    internal sealed class SwapExpressionVisitor : ExpressionVisitor
+    {
+        private readonly Expression _from, _to;
+        private SwapExpressionVisitor(Expression from, Expression to)
+        {
+            _from = @from;
+            _to = to;
+        }
+
+        /// <summary>
+        /// Swaps <paramref name="from"/> expression with <paramref name="to"/> expression within a given lambda
+        /// </summary>
+        /// <param name="lambda">Lambda expression to perform swap on</param>
+        /// <param name="from">Existing expression to locate</param>
+        /// <param name="to">Expression to replace </param>
+        /// <returns>Re-configured expression</returns>
+        public static Expression<T> Swap<T>(Expression<T> lambda, Expression from, Expression to)
+        {
+            return Expression.Lambda<T>(Swap(lambda.Body, from, to), lambda.Parameters);
+        }
+
+        private static Expression Swap(Expression body, Expression from, Expression to)
+        {
+            return new SwapExpressionVisitor(from, to).Visit(body);
+        }
+
+        public override Expression Visit(Expression node)
+        {
+            return node == _from ? _to : base.Visit(node);
+        }
+    }
+}

--- a/SearchExtensions.sln
+++ b/SearchExtensions.sln
@@ -13,33 +13,72 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NinjaNye.SearchExtensions.T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{35E478DF-0651-48E1-8F07-F8DBE2689088}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NinjaNye.SearchExtensions.Portable", "NinjaNye.SearchExtensions.Portable\NinjaNye.SearchExtensions.Portable.csproj", "{8EB3D1B8-0592-471A-829B-B7C776C37CAA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NinjaNye.SearchExtensions.Portable.Tests", "NinjaNye.SearchExtensions.Portable.Tests\NinjaNye.SearchExtensions.Portable.Tests.csproj", "{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{60B8E347-999F-4EE2-8172-9367D4F71860}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{60B8E347-999F-4EE2-8172-9367D4F71860}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60B8E347-999F-4EE2-8172-9367D4F71860}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{60B8E347-999F-4EE2-8172-9367D4F71860}.Debug|x86.Build.0 = Debug|Any CPU
 		{60B8E347-999F-4EE2-8172-9367D4F71860}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{60B8E347-999F-4EE2-8172-9367D4F71860}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60B8E347-999F-4EE2-8172-9367D4F71860}.Release|x86.ActiveCfg = Release|Any CPU
+		{60B8E347-999F-4EE2-8172-9367D4F71860}.Release|x86.Build.0 = Release|Any CPU
 		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Debug|x86.Build.0 = Debug|Any CPU
 		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Release|x86.ActiveCfg = Release|Any CPU
+		{A2B64396-FE41-4F02-9A11-5050F16524C3}.Release|x86.Build.0 = Release|Any CPU
 		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Debug|x86.Build.0 = Debug|Any CPU
 		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Release|x86.ActiveCfg = Release|Any CPU
+		{3BA8EC52-60C1-41E6-B154-53D40407115B}.Release|x86.Build.0 = Release|Any CPU
 		{F167ED45-5E0B-4085-A040-2784116A70FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F167ED45-5E0B-4085-A040-2784116A70FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F167ED45-5E0B-4085-A040-2784116A70FD}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F167ED45-5E0B-4085-A040-2784116A70FD}.Debug|x86.Build.0 = Debug|Any CPU
 		{F167ED45-5E0B-4085-A040-2784116A70FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F167ED45-5E0B-4085-A040-2784116A70FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F167ED45-5E0B-4085-A040-2784116A70FD}.Release|x86.ActiveCfg = Release|Any CPU
+		{F167ED45-5E0B-4085-A040-2784116A70FD}.Release|x86.Build.0 = Release|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Debug|x86.Build.0 = Debug|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Release|x86.ActiveCfg = Release|Any CPU
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA}.Release|x86.Build.0 = Release|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Debug|x86.Build.0 = Debug|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Release|x86.ActiveCfg = Release|Any CPU
+		{FAFE908A-DBA5-45FB-8562-6A1A38482F6A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{60B8E347-999F-4EE2-8172-9367D4F71860} = {35E478DF-0651-48E1-8F07-F8DBE2689088}
+		{8EB3D1B8-0592-471A-829B-B7C776C37CAA} = {35E478DF-0651-48E1-8F07-F8DBE2689088}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
#14 

This awesome library only works in projects that target the full .NET framework. For developers targeting a portable version of .NET (mobile app development, for example), it doesn't work. This addition adds a PCL (Portable Class Library) version of the base library, and a unit test project for that library. It is basically a copy of the main library, with some minor changes in the reflection methods used.