### PR TITLE
Expose the final predicate.

### DIFF
--- a/NinjaNye.SearchExtensions/QueryableSearchBase.cs
+++ b/NinjaNye.SearchExtensions/QueryableSearchBase.cs
@@ -45,9 +45,9 @@ namespace NinjaNye.SearchExtensions
             }
 
             _expressionUpdated = true;
-            
-            var finalExpression = Expression.Lambda<Func<TSource, bool>>(CompleteExpression, FirstParameter);
-            Source = Source.Where(finalExpression);
+
+            FinalPredicate = Expression.Lambda<Func<TSource, bool>>(CompleteExpression, FirstParameter);
+            Source = Source.Where(FinalPredicate);
         }
 
         protected void QueryInclude(string path)

--- a/NinjaNye.SearchExtensions/SearchBase.cs
+++ b/NinjaNye.SearchExtensions/SearchBase.cs
@@ -9,6 +9,7 @@ namespace NinjaNye.SearchExtensions
 {
     public abstract class SearchBase<TSource, TType, TPropertyType> where TSource : IEnumerable<TType>
     {
+        public Expression<Func<TType, bool>> FinalPredicate;
         protected TSource Source;
         protected Expression CompleteExpression;
         protected readonly Expression<Func<TType, TPropertyType>>[] Properties;


### PR DESCRIPTION
This will allow others to use SearchExtensions to build up whatever predicate they need, and they can then store or pass around the predicate instead of being forced to execute the source IQueryable.

@ninjanye I need some help with the tests. I could not just clone and run tests in Visual Studio. I believe you need to update the test runners. This may be a good time to target the latest netstandard2.0 and bump all your package versions.