### PR TITLE
ExpressionParser added.

### DIFF
--- a/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/Parsing/ExpressionParserTests.cs
+++ b/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/Parsing/ExpressionParserTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq.Expressions;
+using NinjaNye.SearchExtensions.Parsing;
+using Xunit;
+
+namespace NinjaNye.SearchExtensions.Tests.SearchExtensionTests.Parsing
+{
+    public class ExpressionParserTests
+    {
+        [Fact]
+        public void Parse_ReturnsCorrectResult()
+        {
+            const string expressionString = "Child.Message";
+
+            var expression = ExpressionParser.Parse<TestObject, string>(expressionString);
+
+            var parameterExpression = Assert.Single(expression.Parameters);
+            Assert.Equal(typeof(TestObject), parameterExpression.Type);
+
+            var memberExpression = expression.Body as MemberExpression;
+            Assert.NotNull(memberExpression);
+            Assert.Equal("Message", memberExpression.Member.Name);
+            
+            memberExpression = memberExpression.Expression as MemberExpression;
+            Assert.NotNull(memberExpression);
+            Assert.Equal("Child", memberExpression.Member.Name);
+
+            Assert.Equal(parameterExpression, memberExpression.Expression);
+        }
+
+        [Fact]
+        public void ParseProperties_ReturnsCorrectResult()
+        {
+            const string Expression = "Property1.Property2";
+
+            string[] properties = ExpressionParser.ParseProperties(Expression);
+
+            Assert.Equal(2, properties.Length);
+            Assert.Equal("Property1", properties[0]);
+            Assert.Equal("Property2", properties[1]);
+        }
+
+        [Fact]
+        public void ParseProperties_EmptyExpression_ThrowsException()
+        {
+            const string expression = null;
+
+            Action act = () => ExpressionParser.ParseProperties(expression);
+
+            Assert.Throws<ArgumentException>(act);
+        }
+
+        [Fact]
+        public void ParseProperties_InvalidExpression_ThrowsException()
+        {
+            const string expression = "Test\\Child";
+
+            Action act = () => ExpressionParser.ParseProperties(expression);
+
+            Assert.Throws<ArgumentException>(act);
+        }
+        
+        [Fact]
+        public void CreateLambdaExpression_NullPropertyCollection_ThrowsException()
+        {
+            const string[] properties = null;
+
+            Action act = () => ExpressionParser.CreateLambdaExpression<TestObject, string>(properties);
+
+            Assert.Throws<ArgumentNullException>(act);
+        }
+        
+        [Fact]
+        public void CreateLambdaExpression_EmptyPropertyCollection_ThrowsException()
+        {
+            string[] properties = new string[0];
+
+            Action act = () => ExpressionParser.CreateLambdaExpression<TestObject, string>(properties);
+
+            Assert.Throws<ArgumentException>(act);
+        }
+        
+        [Fact]
+        public void CreateLambdaExpression_WrongReturnType_ThrowsException()
+        {
+            string[] properties = new[] { "Child" };
+
+            Action act = () => ExpressionParser.CreateLambdaExpression<TestObject, string>(properties);
+
+            Assert.Throws<TypeMismatchException>(act);
+        }
+        
+        [Fact]
+        public void CreateLambdaExpression_NonExistingProperty_ThrowsException()
+        {
+            string[] properties = new[] { "NonExistingProperty" };
+
+            Action act = () => ExpressionParser.CreateLambdaExpression<TestObject, string>(properties);
+
+            Assert.Throws<ArgumentException>(act);
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/Parsing/TestObject.cs
+++ b/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/Parsing/TestObject.cs
@@ -1,0 +1,7 @@
+namespace NinjaNye.SearchExtensions.Tests.SearchExtensionTests.Parsing
+{
+    public class TestObject
+    {
+        public TestObjectChild Child { get; set; }
+    }
+}

--- a/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/Parsing/TestObjectChild.cs
+++ b/NinjaNye.SearchExtensions.Tests/SearchExtensionTests/Parsing/TestObjectChild.cs
@@ -1,0 +1,7 @@
+namespace NinjaNye.SearchExtensions.Tests.SearchExtensionTests.Parsing
+{
+    public class TestObjectChild
+    {
+        public string Message { get; set; }
+    }
+}

--- a/NinjaNye.SearchExtensions/Parsing/ExpressionParser.cs
+++ b/NinjaNye.SearchExtensions/Parsing/ExpressionParser.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace NinjaNye.SearchExtensions.Parsing
+{
+    public static class ExpressionParser
+    {
+        private static Regex ParserRegex = new Regex(
+        @"^(?:
+                    (
+                        [_\p{Lu}\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]
+                        [\p{Lu}\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}\p{Nd}\p{Pc}\p{Cf}\p{Mn}\p{Mc}]*
+                    )
+                    (?:\.(?!$)|$)
+                )+$", RegexOptions.IgnorePatternWhitespace);
+        
+        /// <summary>
+        /// Parses <see cref="string"/> into <see cref="Expression{TDelegate}"/>.
+        /// </summary>
+        /// <param name="expression"><see cref="string"/> to be parsed.</param>
+        /// <typeparam name="TSource">The type of source.</typeparam>
+        /// <typeparam name="TResult">The type of result.</typeparam>
+        /// <returns>Returns <see cref="Expression{TDelegate}"/> for <paramref name="expression"/>.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="expression"/> is null.</exception>
+        /// <exception cref="ArgumentException"><paramref name="expression"/> is empty.</exception>
+        /// <exception cref="TypeMismatchException">Return type of <paramref name="expression"/> is not compatible with the <typeparamref name="TResult"/>.</exception>
+        public static Expression<Func<TSource, TResult>> Parse<TSource, TResult>(string expression)
+        {
+            string[] properties = ParseProperties(expression);
+            return CreateLambdaExpression<TSource, TResult>(properties);
+        }
+
+        internal static Expression<Func<TSource, TResult>> CreateLambdaExpression<TSource, TResult>(string[] properties)
+        {
+            if (properties == null) throw new ArgumentNullException(nameof(properties));
+            if (properties.Length == 0)
+                throw new ArgumentException("Value cannot be an empty collection.", nameof(properties));
+
+            var parameterExpression = Expression.Parameter(typeof(TSource));
+            Expression body = parameterExpression;
+            for (int i = 0; i < properties.Length; i++)
+            {
+                string propertyName = properties[i];
+                body = Expression.Property(body, propertyName);
+            }
+            
+            if (!typeof(TResult).GetTypeInfo().IsAssignableFrom(body.Type.GetTypeInfo())) throw new TypeMismatchException($"{body.Type} is not assignable to {typeof(TResult)}");
+
+            return Expression.Lambda<Func<TSource, TResult>>(body, parameterExpression);
+        }
+
+        internal static string[] ParseProperties(string expression)
+        {
+            if (string.IsNullOrEmpty(expression))
+                throw new ArgumentException("Value cannot be null or empty.", nameof(expression));
+
+            var match = ParserRegex.Match(expression);
+            if (!match.Success) throw new ArgumentException($"{expression} is not a valid expression", nameof(expression));
+
+            var captures = match.Groups[1].Captures;
+            string[] properties = new string[captures.Count];
+            for (int i = 0; i < captures.Count; i++)
+            {
+                string propertyName = captures[i].Value;
+                properties[i] = propertyName;
+            }
+
+            return properties;
+        }
+    }
+}

--- a/NinjaNye.SearchExtensions/Parsing/TypeMismatchException.cs
+++ b/NinjaNye.SearchExtensions/Parsing/TypeMismatchException.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace NinjaNye.SearchExtensions.Parsing
+{
+    public class TypeMismatchException : Exception
+    {
+        public TypeMismatchException(string message): base (message) { }
+    }
+}


### PR DESCRIPTION
This PR fixes #27. With this, you will be able to create simple Expression from string.

Example usage:
```
var expression = ExpressionParser.Parse<Order, string>("Customer.Address.City");
var search = orders.Search(expression);
```