### PR TITLE
Conditional Package

### DIFF
--- a/NinjaNye.SearchExtensions/NinjaNye.SearchExtensions.csproj
+++ b/NinjaNye.SearchExtensions/NinjaNye.SearchExtensions.csproj
@@ -11,7 +11,7 @@
     <Authors>John Nye</Authors>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'net481'">
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This prevents a redundant chain of implicit packages to be pulled for .netstandard2.1 and net8.0.